### PR TITLE
Fix aXe output for improperly incrementing header numbers

### DIFF
--- a/src/components/GradebookHeader/__snapshots__/test.jsx.snap
+++ b/src/components/GradebookHeader/__snapshots__/test.jsx.snap
@@ -29,9 +29,9 @@ exports[`GradebookHeader component snapshots default values (grades frozen, cann
   <div
     className="subtitle-row d-flex justify-content-between align-items-center"
   >
-    <h3>
+    <h2>
       fakeID
-    </h3>
+    </h2>
   </div>
   <div
     className="alert alert-warning"
@@ -75,9 +75,9 @@ exports[`GradebookHeader component snapshots grades frozen, can view. grades fro
   <div
     className="subtitle-row d-flex justify-content-between align-items-center"
   >
-    <h3>
+    <h2>
       fakeID
-    </h3>
+    </h2>
   </div>
   <div
     className="alert alert-warning"
@@ -121,9 +121,9 @@ exports[`GradebookHeader component snapshots grades frozen, cannot view unauthor
   <div
     className="subtitle-row d-flex justify-content-between align-items-center"
   >
-    <h3>
+    <h2>
       fakeID
-    </h3>
+    </h2>
   </div>
   <div
     className="alert alert-warning"
@@ -177,9 +177,9 @@ exports[`GradebookHeader component snapshots show bulk management, active view i
   <div
     className="subtitle-row d-flex justify-content-between align-items-center"
   >
-    <h3>
+    <h2>
       fakeID
-    </h3>
+    </h2>
     <Button
       onClick={[MockFunction this.handleToggleViewClick]}
       variant="tertiary"
@@ -233,9 +233,9 @@ exports[`GradebookHeader component snapshots show bulk management, active view i
   <div
     className="subtitle-row d-flex justify-content-between align-items-center"
   >
-    <h3>
+    <h2>
       fakeID
-    </h3>
+    </h2>
     <Button
       onClick={[MockFunction this.handleToggleViewClick]}
       variant="tertiary"

--- a/src/components/GradebookHeader/index.jsx
+++ b/src/components/GradebookHeader/index.jsx
@@ -47,7 +47,7 @@ export class GradebookHeader extends React.Component {
           <FormattedMessage {...messages.gradebook} />
         </h1>
         <div className="subtitle-row d-flex justify-content-between align-items-center">
-          <h3>{this.props.courseId}</h3>
+          <h2>{this.props.courseId}</h2>
           { this.props.showBulkManagement && (
             <Button
               variant="tertiary"

--- a/src/components/GradesView/GradesView.scss
+++ b/src/components/GradesView/GradesView.scss
@@ -24,7 +24,7 @@
     .search-help-text {
         margin-left: 20px;
     }
-    h4 {
+    h3 {
         font-weight: bold;
         margin-top: 0rem;
     }

--- a/src/components/GradesView/__snapshots__/test.jsx.snap
+++ b/src/components/GradesView/__snapshots__/test.jsx.snap
@@ -4,7 +4,7 @@ exports[`GradesView Component snapshots basic snapshot 1`] = `
 <React.Fragment>
   <SpinnerIcon />
   <InterventionsReport />
-  <h4
+  <h3
     className="step-message-1"
   >
     <FormattedMessage
@@ -12,7 +12,7 @@ exports[`GradesView Component snapshots basic snapshot 1`] = `
       description="Filter controls container heading string"
       id="gradebook.GradesView.filterHeading"
     />
-  </h4>
+  </h3>
   <div
     className="d-flex justify-content-between"
   >
@@ -23,13 +23,13 @@ exports[`GradesView Component snapshots basic snapshot 1`] = `
     handleClose={[MockFunction this.handleFilterBadgeClose]}
   />
   <StatusAlerts />
-  <h4>
+  <h3>
     <FormattedMessage
       defaultMessage="Step 2: View or Modify Individual Grades"
       description="Alert text for invalid minimum course grade"
       id="gradebook.GradesView.gradebookStepHeading"
     />
-  </h4>
+  </h3>
   <div
     className="d-flex justify-content-between align-items-center mb-2"
   >

--- a/src/components/GradesView/index.jsx
+++ b/src/components/GradesView/index.jsx
@@ -46,9 +46,9 @@ export class GradesView extends React.Component {
         <SpinnerIcon />
 
         <InterventionsReport />
-        <h4 className="step-message-1">
+        <h3 className="step-message-1">
           <FormattedMessage {...messages.filterStepHeading} />
-        </h4>
+        </h3>
 
         <div className="d-flex justify-content-between">
           <FilterMenuToggle />
@@ -58,7 +58,7 @@ export class GradesView extends React.Component {
         <FilterBadges handleClose={this.handleFilterBadgeClose} />
         <StatusAlerts />
 
-        <h4><FormattedMessage {...messages.gradebookStepHeading} /></h4>
+        <h3><FormattedMessage {...messages.gradebookStepHeading} /></h3>
 
         <div className="d-flex justify-content-between align-items-center mb-2">
           <ScoreViewInput />


### PR DESCRIPTION
This is ow aXe reports that error when run from the browser against a non-Master's course gradebook:

<img width="1440" alt="Screen Shot 2020-05-18 at 4 32 05 PM" src="https://user-images.githubusercontent.com/6405097/82256947-33325e00-9925-11ea-8b64-aa4e3e20a57a.png">
