### PR TITLE
fix: build the course id properly when MFE is deployed in a subdirectory

### DIFF
--- a/src/data/services/lms/urls.js
+++ b/src/data/services/lms/urls.js
@@ -5,7 +5,7 @@ import { filterQuery, stringifyUrl } from './utils';
 
 const baseUrl = `${configuration.LMS_BASE_URL}`;
 
-const courseId = window.location.pathname.slice(1);
+const courseId = window.location.pathname.split('/').filter(Boolean).pop() || '';
 
 const api = `${baseUrl}/api/`;
 const bulkGrades = `${api}bulk_grades/course/${courseId}/`;


### PR DESCRIPTION
**DESCRIPTION**

This PR aims to fix an issue related to the **courseId** extraction from the browser pathname. The current version of the code assumes the Gradebook MFE is deployed in a subdomain (for instance `gradebook.my.site`), however, an MFE can be deployed in a subdirectory (for instance `mfes.my.site/gradebook`). When using subdirectories, the **courseId** is wrongly calculated, and the URLs built upon this value will be also incorrect. If the pathname in the browser is `/gradebook/course-v1:org+course+run` the calculated **courseId** is `gradebook/course-v1:org+course+run` and from here, the MFE breaks since LMS API calls will fail. With this change, the **courseId** is calculated properly for both deployment cases.

**What changed?**

- The way **courseId** is calculated to build LMS API endpoints

**Developer Checklist**
- [ ] Test suites passing
- [ ] Documentation and test plan updated, if applicable
- [ ] Received code-owner approving review
- [ ] Bumped version number [package.json](../package.json)

**Testing Instructions**

- Serve the MFE through a subdirectory and try to access the Gradebook for a course 

**Reviewer Checklist**

@edx/content-aurora 

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review
- [ ] I've tested the new functionality


FYI: @edx/masters-devs-gta
