### PR TITLE
refactor: reduce scss custom variables and classes

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "semantic-release": "semantic-release",
     "start": "fedx-scripts webpack-dev-server --progress",
     "test": "TZ=GMT fedx-scripts jest --coverage --passWithNoTests",
-    "watch-tests": "jest --watch"
+    "watch-tests": "jest --watch",
+    "update-snapshots": "jest --updateSnapshot"
   },
   "author": "edX",
   "license": "AGPL-3.0",

--- a/src/App.scss
+++ b/src/App.scss
@@ -13,6 +13,4 @@ $input-focus-box-shadow: $input-box-shadow; // hack to get upgrade to paragon 4.
 @import "~@edx/frontend-component-footer/dist/_footer";
 
 @import "./components/GradesView/GradesView";
-@import "./components/BulkManagementHistoryView/BulkManagementHistoryView";
 @import "./components/WithSidebar/WithSidebar";
-@import "./components/GradebookFilters/GradebookFilters";

--- a/src/App.scss
+++ b/src/App.scss
@@ -13,4 +13,5 @@ $input-focus-box-shadow: $input-box-shadow; // hack to get upgrade to paragon 4.
 @import "~@edx/frontend-component-footer/dist/_footer";
 
 @import "./components/GradesView/GradesView";
+@import "./components/BulkManagementHistoryView/BulkManagementHistoryView";
 @import "./components/WithSidebar/WithSidebar";

--- a/src/components/BulkManagementHistoryView/BulkManagementHistoryView.scss
+++ b/src/components/BulkManagementHistoryView/BulkManagementHistoryView.scss
@@ -1,0 +1,6 @@
+.bulk-management-history-view {
+  .help-text {
+    margin-bottom: 40px;
+    max-width: 70%;
+  }
+}

--- a/src/components/BulkManagementHistoryView/BulkManagementHistoryView.scss
+++ b/src/components/BulkManagementHistoryView/BulkManagementHistoryView.scss
@@ -1,6 +1,0 @@
-.bulk-management-history-view {
-  .help-text {
-    margin-bottom: 40px;
-    max-width: 70%;
-  }
-}

--- a/src/components/BulkManagementHistoryView/HistoryTable.jsx
+++ b/src/components/BulkManagementHistoryView/HistoryTable.jsx
@@ -17,8 +17,8 @@ export const mapHistoryRows = ({
   ...rest
 }) => ({
   resultsSummary: (<ResultsSummary {...resultsSummary} />),
-  filename: (<span className="text-wrap">{originalFilename}</span>),
-  user: (<span className="text-wrap">{user}</span>),
+  filename: (<span className="text-break">{originalFilename}</span>),
+  user: (<span className="text-break">{user}</span>),
   ...rest,
 });
 

--- a/src/components/BulkManagementHistoryView/HistoryTable.jsx
+++ b/src/components/BulkManagementHistoryView/HistoryTable.jsx
@@ -17,8 +17,8 @@ export const mapHistoryRows = ({
   ...rest
 }) => ({
   resultsSummary: (<ResultsSummary {...resultsSummary} />),
-  filename: (<span className="wrap-text-in-cell">{originalFilename}</span>),
-  user: (<span className="wrap-text-in-cell">{user}</span>),
+  filename: (<span className="text-wrap">{originalFilename}</span>),
+  user: (<span className="text-wrap">{user}</span>),
   ...rest,
 });
 

--- a/src/components/BulkManagementHistoryView/HistoryTable.test.jsx
+++ b/src/components/BulkManagementHistoryView/HistoryTable.test.jsx
@@ -75,15 +75,15 @@ describe('HistoryTable', () => {
           test(fieldAssertions.join(', '), () => {
             const rows = table.props().data;
             expect(rows[0].resultsSummary).toEqual(<ResultsSummary {...entry1.resultsSummary} />);
-            expect(rows[0].user).toEqual(<span className="wrap-text-in-cell">{entry1.user}</span>);
+            expect(rows[0].user).toEqual(<span className="text-wrap">{entry1.user}</span>);
             expect(
               rows[0].filename,
-            ).toEqual(<span className="wrap-text-in-cell">{entry1.originalFilename}</span>);
+            ).toEqual(<span className="text-wrap">{entry1.originalFilename}</span>);
             expect(rows[1].resultsSummary).toEqual(<ResultsSummary {...entry2.resultsSummary} />);
-            expect(rows[1].user).toEqual(<span className="wrap-text-in-cell">{entry2.user}</span>);
+            expect(rows[1].user).toEqual(<span className="text-wrap">{entry2.user}</span>);
             expect(
               rows[1].filename,
-            ).toEqual(<span className="wrap-text-in-cell">{entry2.originalFilename}</span>);
+            ).toEqual(<span className="text-wrap">{entry2.originalFilename}</span>);
           });
         });
         test('columns from bulkManagementColumns', () => {

--- a/src/components/BulkManagementHistoryView/HistoryTable.test.jsx
+++ b/src/components/BulkManagementHistoryView/HistoryTable.test.jsx
@@ -75,15 +75,15 @@ describe('HistoryTable', () => {
           test(fieldAssertions.join(', '), () => {
             const rows = table.props().data;
             expect(rows[0].resultsSummary).toEqual(<ResultsSummary {...entry1.resultsSummary} />);
-            expect(rows[0].user).toEqual(<span className="text-wrap">{entry1.user}</span>);
+            expect(rows[0].user).toEqual(<span className="text-break">{entry1.user}</span>);
             expect(
               rows[0].filename,
-            ).toEqual(<span className="text-wrap">{entry1.originalFilename}</span>);
+            ).toEqual(<span className="text-break">{entry1.originalFilename}</span>);
             expect(rows[1].resultsSummary).toEqual(<ResultsSummary {...entry2.resultsSummary} />);
-            expect(rows[1].user).toEqual(<span className="text-wrap">{entry2.user}</span>);
+            expect(rows[1].user).toEqual(<span className="text-break">{entry2.user}</span>);
             expect(
               rows[1].filename,
-            ).toEqual(<span className="text-wrap">{entry2.originalFilename}</span>);
+            ).toEqual(<span className="text-break">{entry2.originalFilename}</span>);
           });
         });
         test('columns from bulkManagementColumns', () => {

--- a/src/components/BulkManagementHistoryView/__snapshots__/HistoryTable.test.jsx.snap
+++ b/src/components/BulkManagementHistoryView/__snapshots__/HistoryTable.test.jsx.snap
@@ -4,7 +4,7 @@ exports[`HistoryTable component snapshot history table data (from bulkManagement
 Array [
   Object {
     "filename": <span
-      className="wrap-text-in-cell"
+      className="text-wrap"
     >
       blue.png
     </span>,
@@ -15,14 +15,14 @@ Array [
     />,
     "timeUploaded": "65",
     "user": <span
-      className="wrap-text-in-cell"
+      className="text-wrap"
     >
       Eifel
     </span>,
   },
   Object {
     "filename": <span
-      className="wrap-text-in-cell"
+      className="text-wrap"
     >
       allStar.jpg
     </span>,
@@ -33,7 +33,7 @@ Array [
     />,
     "timeUploaded": "2000s?",
     "user": <span
-      className="wrap-text-in-cell"
+      className="text-wrap"
     >
       Smashmouth
     </span>,
@@ -76,7 +76,7 @@ exports[`HistoryTable component snapshot snapshot - loads formatted table 1`] = 
     Array [
       Object {
         "filename": <span
-          className="wrap-text-in-cell"
+          className="text-wrap"
         >
           blue.png
         </span>,
@@ -87,14 +87,14 @@ exports[`HistoryTable component snapshot snapshot - loads formatted table 1`] = 
         />,
         "timeUploaded": "65",
         "user": <span
-          className="wrap-text-in-cell"
+          className="text-wrap"
         >
           Eifel
         </span>,
       },
       Object {
         "filename": <span
-          className="wrap-text-in-cell"
+          className="text-wrap"
         >
           allStar.jpg
         </span>,
@@ -105,7 +105,7 @@ exports[`HistoryTable component snapshot snapshot - loads formatted table 1`] = 
         />,
         "timeUploaded": "2000s?",
         "user": <span
-          className="wrap-text-in-cell"
+          className="text-wrap"
         >
           Smashmouth
         </span>,

--- a/src/components/BulkManagementHistoryView/__snapshots__/HistoryTable.test.jsx.snap
+++ b/src/components/BulkManagementHistoryView/__snapshots__/HistoryTable.test.jsx.snap
@@ -4,7 +4,7 @@ exports[`HistoryTable component snapshot history table data (from bulkManagement
 Array [
   Object {
     "filename": <span
-      className="text-wrap"
+      className="text-break"
     >
       blue.png
     </span>,
@@ -15,14 +15,14 @@ Array [
     />,
     "timeUploaded": "65",
     "user": <span
-      className="text-wrap"
+      className="text-break"
     >
       Eifel
     </span>,
   },
   Object {
     "filename": <span
-      className="text-wrap"
+      className="text-break"
     >
       allStar.jpg
     </span>,
@@ -33,7 +33,7 @@ Array [
     />,
     "timeUploaded": "2000s?",
     "user": <span
-      className="text-wrap"
+      className="text-break"
     >
       Smashmouth
     </span>,
@@ -76,7 +76,7 @@ exports[`HistoryTable component snapshot snapshot - loads formatted table 1`] = 
     Array [
       Object {
         "filename": <span
-          className="text-wrap"
+          className="text-break"
         >
           blue.png
         </span>,
@@ -87,14 +87,14 @@ exports[`HistoryTable component snapshot snapshot - loads formatted table 1`] = 
         />,
         "timeUploaded": "65",
         "user": <span
-          className="text-wrap"
+          className="text-break"
         >
           Eifel
         </span>,
       },
       Object {
         "filename": <span
-          className="text-wrap"
+          className="text-break"
         >
           allStar.jpg
         </span>,
@@ -105,7 +105,7 @@ exports[`HistoryTable component snapshot snapshot - loads formatted table 1`] = 
         />,
         "timeUploaded": "2000s?",
         "user": <span
-          className="text-wrap"
+          className="text-break"
         >
           Smashmouth
         </span>,

--- a/src/components/BulkManagementHistoryView/__snapshots__/index.test.jsx.snap
+++ b/src/components/BulkManagementHistoryView/__snapshots__/index.test.jsx.snap
@@ -4,7 +4,9 @@ exports[`BulkManagementHistoryView component snapshot snapshot - loads heading f
 <div
   className="bulk-management-history-view"
 >
-  <h4>
+  <h4
+    className="font-weight-bold mt-0"
+  >
     <FormattedMessage
       defaultMessage="Bulk Management History"
       description="Heading text for BulkManagement History Tab"
@@ -12,7 +14,7 @@ exports[`BulkManagementHistoryView component snapshot snapshot - loads heading f
     />
   </h4>
   <p
-    className="help-text"
+    className="pb-5 w-75"
   >
     <FormattedMessage
       defaultMessage="Below is a log of previous grade imports.  To download a CSV of your gradebook and import grades for override, return to the Gradebook.  Please note, after importing grades, it may take a few seconds to process the override."

--- a/src/components/BulkManagementHistoryView/__snapshots__/index.test.jsx.snap
+++ b/src/components/BulkManagementHistoryView/__snapshots__/index.test.jsx.snap
@@ -14,7 +14,7 @@ exports[`BulkManagementHistoryView component snapshot snapshot - loads heading f
     />
   </h4>
   <p
-    className="pb-5 w-75"
+    className="help-text"
   >
     <FormattedMessage
       defaultMessage="Below is a log of previous grade imports.  To download a CSV of your gradebook and import grades for override, return to the Gradebook.  Please note, after importing grades, it may take a few seconds to process the override."

--- a/src/components/BulkManagementHistoryView/index.jsx
+++ b/src/components/BulkManagementHistoryView/index.jsx
@@ -13,7 +13,7 @@ import HistoryTable from './HistoryTable';
 export const BulkManagementHistoryView = () => (
   <div className="bulk-management-history-view">
     <h4 className="font-weight-bold mt-0"><FormattedMessage {...messages.heading} /></h4>
-    <p className="pb-5 w-75">
+    <p className="help-text">
       <FormattedMessage {...messages.helpText} />
     </p>
     <BulkManagementAlerts />

--- a/src/components/BulkManagementHistoryView/index.jsx
+++ b/src/components/BulkManagementHistoryView/index.jsx
@@ -12,8 +12,8 @@ import HistoryTable from './HistoryTable';
  */
 export const BulkManagementHistoryView = () => (
   <div className="bulk-management-history-view">
-    <h4><FormattedMessage {...messages.heading} /></h4>
-    <p className="help-text">
+    <h4 className="font-weight-bold mt-0"><FormattedMessage {...messages.heading} /></h4>
+    <p className="pb-5 w-75">
       <FormattedMessage {...messages.helpText} />
     </p>
     <BulkManagementAlerts />

--- a/src/components/BulkManagementHistoryView/index.test.jsx
+++ b/src/components/BulkManagementHistoryView/index.test.jsx
@@ -29,7 +29,7 @@ describe('BulkManagementHistoryView', () => {
       test('heading - h4 loaded from messages', () => {
         const heading = el.find('h4');
         expect(heading.getElement()).toEqual((
-          <h4>
+          <h4 className="font-weight-bold mt-0">
             <FormattedMessage {...messages.heading} />
           </h4>
         ));

--- a/src/components/GradebookFilters/AssignmentFilter/__snapshots__/test.jsx.snap
+++ b/src/components/GradebookFilters/AssignmentFilter/__snapshots__/test.jsx.snap
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`AssignmentFilter Component snapshots basic snapshot 1`] = `
-<div
-  className="student-filters"
->
+<div>
   <SelectGroup
     disabled={false}
     id="assignment"

--- a/src/components/GradebookFilters/AssignmentFilter/index.jsx
+++ b/src/components/GradebookFilters/AssignmentFilter/index.jsx
@@ -46,7 +46,7 @@ export class AssignmentFilter extends React.Component {
 
   render() {
     return (
-      <div className="student-filters">
+      <div>
         <SelectGroup
           id="assignment"
           label={<FormattedMessage {...messages.assignment} />}

--- a/src/components/GradebookFilters/AssignmentGradeFilter/__snapshots__/test.jsx.snap
+++ b/src/components/GradebookFilters/AssignmentGradeFilter/__snapshots__/test.jsx.snap
@@ -1,37 +1,47 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`AssignmentGradeFilter Component snapshots buttons and groups disabled if no selected assignment 1`] = `
-<div
-  className="grade-filter-inputs"
->
-  <PercentGroup
-    disabled={true}
-    id="assignmentGradeMin"
-    label={
-      <FormattedMessage
-        defaultMessage="Min Grade"
-        description="Min-grade filter select label in Gradebook Filters"
-        id="gradebook.GradebookFilters.minGradeFilterLabel"
-      />
-    }
-    onChange={[MockFunction handleSetMin]}
-    value="2"
-  />
-  <PercentGroup
-    disabled={true}
-    id="assignmentGradeMax"
-    label={
-      <FormattedMessage
-        defaultMessage="Max Grade"
-        description="Max-grade filter select label in Gradebook Filters"
-        id="gradebook.GradebookFilters.maxGradeFilterLabel"
-      />
-    }
-    onChange={[MockFunction handleSetMax]}
-    value="98"
-  />
+<React.Fragment>
   <div
-    className="grade-filter-action"
+    className="row"
+  >
+    <div
+      className="col-5 pr-0"
+    >
+      <PercentGroup
+        disabled={true}
+        id="assignmentGradeMin"
+        label={
+          <FormattedMessage
+            defaultMessage="Min Grade"
+            description="Min-grade filter select label in Gradebook Filters"
+            id="gradebook.GradebookFilters.minGradeFilterLabel"
+          />
+        }
+        onChange={[MockFunction handleSetMin]}
+        value="2"
+      />
+    </div>
+    <div
+      className="col-5 pr-0"
+    >
+      <PercentGroup
+        disabled={true}
+        id="assignmentGradeMax"
+        label={
+          <FormattedMessage
+            defaultMessage="Max Grade"
+            description="Max-grade filter select label in Gradebook Filters"
+            id="gradebook.GradebookFilters.maxGradeFilterLabel"
+          />
+        }
+        onChange={[MockFunction handleSetMax]}
+        value="98"
+      />
+    </div>
+  </div>
+  <div
+    className="text-right"
   >
     <ForwardRef
       active={false}
@@ -44,41 +54,51 @@ exports[`AssignmentGradeFilter Component snapshots buttons and groups disabled i
       Apply
     </ForwardRef>
   </div>
-</div>
+</React.Fragment>
 `;
 
 exports[`AssignmentGradeFilter Component snapshots smoke test 1`] = `
-<div
-  className="grade-filter-inputs"
->
-  <PercentGroup
-    disabled={false}
-    id="assignmentGradeMin"
-    label={
-      <FormattedMessage
-        defaultMessage="Min Grade"
-        description="Min-grade filter select label in Gradebook Filters"
-        id="gradebook.GradebookFilters.minGradeFilterLabel"
-      />
-    }
-    onChange={[MockFunction handleSetMin]}
-    value="2"
-  />
-  <PercentGroup
-    disabled={false}
-    id="assignmentGradeMax"
-    label={
-      <FormattedMessage
-        defaultMessage="Max Grade"
-        description="Max-grade filter select label in Gradebook Filters"
-        id="gradebook.GradebookFilters.maxGradeFilterLabel"
-      />
-    }
-    onChange={[MockFunction handleSetMax]}
-    value="98"
-  />
+<React.Fragment>
   <div
-    className="grade-filter-action"
+    className="row"
+  >
+    <div
+      className="col-5 pr-0"
+    >
+      <PercentGroup
+        disabled={false}
+        id="assignmentGradeMin"
+        label={
+          <FormattedMessage
+            defaultMessage="Min Grade"
+            description="Min-grade filter select label in Gradebook Filters"
+            id="gradebook.GradebookFilters.minGradeFilterLabel"
+          />
+        }
+        onChange={[MockFunction handleSetMin]}
+        value="2"
+      />
+    </div>
+    <div
+      className="col-5 pr-0"
+    >
+      <PercentGroup
+        disabled={false}
+        id="assignmentGradeMax"
+        label={
+          <FormattedMessage
+            defaultMessage="Max Grade"
+            description="Max-grade filter select label in Gradebook Filters"
+            id="gradebook.GradebookFilters.maxGradeFilterLabel"
+          />
+        }
+        onChange={[MockFunction handleSetMax]}
+        value="98"
+      />
+    </div>
+  </div>
+  <div
+    className="text-right"
   >
     <ForwardRef
       active={false}
@@ -91,5 +111,5 @@ exports[`AssignmentGradeFilter Component snapshots smoke test 1`] = `
       Apply
     </ForwardRef>
   </div>
-</div>
+</React.Fragment>
 `;

--- a/src/components/GradebookFilters/AssignmentGradeFilter/__snapshots__/test.jsx.snap
+++ b/src/components/GradebookFilters/AssignmentGradeFilter/__snapshots__/test.jsx.snap
@@ -2,11 +2,12 @@
 
 exports[`AssignmentGradeFilter Component snapshots buttons and groups disabled if no selected assignment 1`] = `
 <React.Fragment>
-  <div
-    className="row"
+  <Row
+    noGutters={false}
   >
-    <div
-      className="col-5 pr-0"
+    <Col
+      className="pr-0"
+      xs={5}
     >
       <PercentGroup
         disabled={true}
@@ -21,9 +22,10 @@ exports[`AssignmentGradeFilter Component snapshots buttons and groups disabled i
         onChange={[MockFunction handleSetMin]}
         value="2"
       />
-    </div>
-    <div
-      className="col-5 pr-0"
+    </Col>
+    <Col
+      className="pr-0"
+      xs={5}
     >
       <PercentGroup
         disabled={true}
@@ -38,10 +40,11 @@ exports[`AssignmentGradeFilter Component snapshots buttons and groups disabled i
         onChange={[MockFunction handleSetMax]}
         value="98"
       />
-    </div>
-  </div>
-  <div
-    className="text-right"
+    </Col>
+  </Row>
+  <ActionRow
+    as="div"
+    isStacked={false}
   >
     <ForwardRef
       active={false}
@@ -53,17 +56,18 @@ exports[`AssignmentGradeFilter Component snapshots buttons and groups disabled i
     >
       Apply
     </ForwardRef>
-  </div>
+  </ActionRow>
 </React.Fragment>
 `;
 
 exports[`AssignmentGradeFilter Component snapshots smoke test 1`] = `
 <React.Fragment>
-  <div
-    className="row"
+  <Row
+    noGutters={false}
   >
-    <div
-      className="col-5 pr-0"
+    <Col
+      className="pr-0"
+      xs={5}
     >
       <PercentGroup
         disabled={false}
@@ -78,9 +82,10 @@ exports[`AssignmentGradeFilter Component snapshots smoke test 1`] = `
         onChange={[MockFunction handleSetMin]}
         value="2"
       />
-    </div>
-    <div
-      className="col-5 pr-0"
+    </Col>
+    <Col
+      className="pr-0"
+      xs={5}
     >
       <PercentGroup
         disabled={false}
@@ -95,10 +100,11 @@ exports[`AssignmentGradeFilter Component snapshots smoke test 1`] = `
         onChange={[MockFunction handleSetMax]}
         value="98"
       />
-    </div>
-  </div>
-  <div
-    className="text-right"
+    </Col>
+  </Row>
+  <ActionRow
+    as="div"
+    isStacked={false}
   >
     <ForwardRef
       active={false}
@@ -110,6 +116,6 @@ exports[`AssignmentGradeFilter Component snapshots smoke test 1`] = `
     >
       Apply
     </ForwardRef>
-  </div>
+  </ActionRow>
 </React.Fragment>
 `;

--- a/src/components/GradebookFilters/AssignmentGradeFilter/index.jsx
+++ b/src/components/GradebookFilters/AssignmentGradeFilter/index.jsx
@@ -40,9 +40,9 @@ export class AssignmentGradeFilter extends React.Component {
       localAssignmentLimits: { assignmentGradeMax, assignmentGradeMin },
     } = this.props;
     return (
-      <div className="d-inline-block">
+      <>
         <div className="row">
-          <div className="col-5">
+          <div className="col-5 pr-0">
             <PercentGroup
               id="assignmentGradeMin"
               label={<FormattedMessage {...messages.minGrade} />}
@@ -51,7 +51,7 @@ export class AssignmentGradeFilter extends React.Component {
               onChange={this.handleSetMin}
             />
           </div>
-          <div className="col-5">
+          <div className="col-5 pr-0">
             <PercentGroup
               id="assignmentGradeMax"
               label={<FormattedMessage {...messages.maxGrade} />}
@@ -72,7 +72,7 @@ export class AssignmentGradeFilter extends React.Component {
             Apply
           </Button>
         </div>
-      </div>
+      </>
     );
   }
 }

--- a/src/components/GradebookFilters/AssignmentGradeFilter/index.jsx
+++ b/src/components/GradebookFilters/AssignmentGradeFilter/index.jsx
@@ -4,7 +4,9 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
-import { ActionRow, Col, Button, Row } from '@edx/paragon';
+import {
+  ActionRow, Col, Button, Row,
+} from '@edx/paragon';
 
 import selectors from 'data/selectors';
 import actions from 'data/actions';

--- a/src/components/GradebookFilters/AssignmentGradeFilter/index.jsx
+++ b/src/components/GradebookFilters/AssignmentGradeFilter/index.jsx
@@ -40,22 +40,28 @@ export class AssignmentGradeFilter extends React.Component {
       localAssignmentLimits: { assignmentGradeMax, assignmentGradeMin },
     } = this.props;
     return (
-      <div className="grade-filter-inputs">
-        <PercentGroup
-          id="assignmentGradeMin"
-          label={<FormattedMessage {...messages.minGrade} />}
-          value={assignmentGradeMin}
-          disabled={!this.props.selectedAssignment}
-          onChange={this.handleSetMin}
-        />
-        <PercentGroup
-          id="assignmentGradeMax"
-          label={<FormattedMessage {...messages.maxGrade} />}
-          value={assignmentGradeMax}
-          disabled={!this.props.selectedAssignment}
-          onChange={this.handleSetMax}
-        />
-        <div className="grade-filter-action">
+      <div className="d-inline-block">
+        <div className="row">
+          <div className="col-5">
+            <PercentGroup
+              id="assignmentGradeMin"
+              label={<FormattedMessage {...messages.minGrade} />}
+              value={assignmentGradeMin}
+              disabled={!this.props.selectedAssignment}
+              onChange={this.handleSetMin}
+            />
+          </div>
+          <div className="col-5">
+            <PercentGroup
+              id="assignmentGradeMax"
+              label={<FormattedMessage {...messages.maxGrade} />}
+              value={assignmentGradeMax}
+              disabled={!this.props.selectedAssignment}
+              onChange={this.handleSetMax}
+            />
+          </div>
+        </div>
+        <div className="text-right">
           <Button
             type="submit"
             variant="outline-secondary"

--- a/src/components/GradebookFilters/AssignmentGradeFilter/index.jsx
+++ b/src/components/GradebookFilters/AssignmentGradeFilter/index.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
-import { Button } from '@edx/paragon';
+import { ActionRow, Col, Button, Row } from '@edx/paragon';
 
 import selectors from 'data/selectors';
 import actions from 'data/actions';
@@ -41,8 +41,8 @@ export class AssignmentGradeFilter extends React.Component {
     } = this.props;
     return (
       <>
-        <div className="row">
-          <div className="col-5 pr-0">
+        <Row>
+          <Col xs={5} className="pr-0">
             <PercentGroup
               id="assignmentGradeMin"
               label={<FormattedMessage {...messages.minGrade} />}
@@ -50,8 +50,8 @@ export class AssignmentGradeFilter extends React.Component {
               disabled={!this.props.selectedAssignment}
               onChange={this.handleSetMin}
             />
-          </div>
-          <div className="col-5 pr-0">
+          </Col>
+          <Col xs={5} className="pr-0">
             <PercentGroup
               id="assignmentGradeMax"
               label={<FormattedMessage {...messages.maxGrade} />}
@@ -59,9 +59,9 @@ export class AssignmentGradeFilter extends React.Component {
               disabled={!this.props.selectedAssignment}
               onChange={this.handleSetMax}
             />
-          </div>
-        </div>
-        <div className="text-right">
+          </Col>
+        </Row>
+        <ActionRow>
           <Button
             type="submit"
             variant="outline-secondary"
@@ -71,7 +71,7 @@ export class AssignmentGradeFilter extends React.Component {
           >
             Apply
           </Button>
-        </div>
+        </ActionRow>
       </>
     );
   }

--- a/src/components/GradebookFilters/AssignmentTypeFilter/__snapshots__/test.jsx.snap
+++ b/src/components/GradebookFilters/AssignmentTypeFilter/__snapshots__/test.jsx.snap
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`AssignmentTypeFilter Component snapshots SelectGroup disabled if no assignmentFilterOptions 1`] = `
-<div
-  className="student-filters"
->
+<div>
   <SelectGroup
     disabled={true}
     id="assignment-types"
@@ -40,9 +38,7 @@ exports[`AssignmentTypeFilter Component snapshots SelectGroup disabled if no ass
 `;
 
 exports[`AssignmentTypeFilter Component snapshots smoke test 1`] = `
-<div
-  className="student-filters"
->
+<div>
   <SelectGroup
     disabled={false}
     id="assignment-types"

--- a/src/components/GradebookFilters/AssignmentTypeFilter/index.jsx
+++ b/src/components/GradebookFilters/AssignmentTypeFilter/index.jsx
@@ -35,7 +35,7 @@ export class AssignmentTypeFilter extends React.Component {
 
   render() {
     return (
-      <div className="student-filters">
+      <div>
         <SelectGroup
           id="assignment-types"
           label={<FormattedMessage {...messages.assignmentTypes} />}

--- a/src/components/GradebookFilters/CourseGradeFilter/__snapshots__/test.jsx.snap
+++ b/src/components/GradebookFilters/CourseGradeFilter/__snapshots__/test.jsx.snap
@@ -2,11 +2,10 @@
 
 exports[`CourseGradeFilter Component snapshots basic snapshot 1`] = `
 <React.Fragment>
-  <div
-    className="row"
-  >
-    <div
-      className="col-5 pr-0"
+  <Row>
+    <Col
+      className="pr-0"
+      xs={5}
     >
       <PercentGroup
         id="minimum-grade"
@@ -20,9 +19,10 @@ exports[`CourseGradeFilter Component snapshots basic snapshot 1`] = `
         onChange={[MockFunction handleUpdateMin]}
         value="5"
       />
-    </div>
-    <div
-      className="col-5 pr-0"
+    </Col>
+    <Col
+      className="pr-0"
+      xs={5}
     >
       <PercentGroup
         id="maximum-grade"
@@ -36,17 +36,15 @@ exports[`CourseGradeFilter Component snapshots basic snapshot 1`] = `
         onChange={[MockFunction handleUpdateMax]}
         value="92"
       />
-    </div>
-  </div>
-  <div
-    className="text-right"
-  >
+    </Col>
+  </Row>
+  <ActionRow>
     <Button
       onClick={[MockFunction handleApplyClick]}
       variant="outline-secondary"
     >
       Apply
     </Button>
-  </div>
+  </ActionRow>
 </React.Fragment>
 `;

--- a/src/components/GradebookFilters/CourseGradeFilter/__snapshots__/test.jsx.snap
+++ b/src/components/GradebookFilters/CourseGradeFilter/__snapshots__/test.jsx.snap
@@ -3,35 +3,43 @@
 exports[`CourseGradeFilter Component snapshots basic snapshot 1`] = `
 <React.Fragment>
   <div
-    className="grade-filter-inputs"
+    className="row"
   >
-    <PercentGroup
-      id="minimum-grade"
-      label={
-        <FormattedMessage
-          defaultMessage="Min Grade"
-          description="Min-grade filter select label in Gradebook Filters"
-          id="gradebook.GradebookFilters.minGradeFilterLabel"
-        />
-      }
-      onChange={[MockFunction handleUpdateMin]}
-      value="5"
-    />
-    <PercentGroup
-      id="maximum-grade"
-      label={
-        <FormattedMessage
-          defaultMessage="Max Grade"
-          description="Max-grade filter select label in Gradebook Filters"
-          id="gradebook.GradebookFilters.maxGradeFilterLabel"
-        />
-      }
-      onChange={[MockFunction handleUpdateMax]}
-      value="92"
-    />
+    <div
+      className="col-5 pr-0"
+    >
+      <PercentGroup
+        id="minimum-grade"
+        label={
+          <FormattedMessage
+            defaultMessage="Min Grade"
+            description="Min-grade filter select label in Gradebook Filters"
+            id="gradebook.GradebookFilters.minGradeFilterLabel"
+          />
+        }
+        onChange={[MockFunction handleUpdateMin]}
+        value="5"
+      />
+    </div>
+    <div
+      className="col-5 pr-0"
+    >
+      <PercentGroup
+        id="maximum-grade"
+        label={
+          <FormattedMessage
+            defaultMessage="Max Grade"
+            description="Max-grade filter select label in Gradebook Filters"
+            id="gradebook.GradebookFilters.maxGradeFilterLabel"
+          />
+        }
+        onChange={[MockFunction handleUpdateMax]}
+        value="92"
+      />
+    </div>
   </div>
   <div
-    className="grade-filter-action"
+    className="text-right"
   >
     <Button
       onClick={[MockFunction handleApplyClick]}

--- a/src/components/GradebookFilters/CourseGradeFilter/index.jsx
+++ b/src/components/GradebookFilters/CourseGradeFilter/index.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
-import { Button } from '@edx/paragon';
+import { ActionRow, Col, Button, Row } from '@edx/paragon';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
 
 import selectors from 'data/selectors';
@@ -48,32 +48,32 @@ export class CourseGradeFilter extends React.Component {
     } = this.props;
     return (
       <>
-        <div className="row">
-          <div className="col-5 pr-0">
+        <Row>
+          <Col xs={5} className="pr-0">
             <PercentGroup
               id="minimum-grade"
               label={<FormattedMessage {...messages.minGrade} />}
               value={courseGradeMin}
               onChange={this.handleUpdateMin}
             />
-          </div>
-          <div className="col-5 pr-0">
+          </Col>
+          <Col xs={5} className="pr-0">
             <PercentGroup
               id="maximum-grade"
               label={<FormattedMessage {...messages.maxGrade} />}
               value={courseGradeMax}
               onChange={this.handleUpdateMax}
             />
-          </div>
-        </div>
-        <div className="text-right">
+          </Col>
+        </Row>
+        <ActionRow>
           <Button
             variant="outline-secondary"
             onClick={this.handleApplyClick}
           >
             Apply
           </Button>
-        </div>
+        </ActionRow>
       </>
     );
   }

--- a/src/components/GradebookFilters/CourseGradeFilter/index.jsx
+++ b/src/components/GradebookFilters/CourseGradeFilter/index.jsx
@@ -49,7 +49,7 @@ export class CourseGradeFilter extends React.Component {
     return (
       <>
         <div className="row">
-          <div className="col-5">
+          <div className="col-5 pr-0">
             <PercentGroup
               id="minimum-grade"
               label={<FormattedMessage {...messages.minGrade} />}
@@ -57,7 +57,7 @@ export class CourseGradeFilter extends React.Component {
               onChange={this.handleUpdateMin}
             />
           </div>
-          <div className="col-5">
+          <div className="col-5 pr-0">
             <PercentGroup
               id="maximum-grade"
               label={<FormattedMessage {...messages.maxGrade} />}

--- a/src/components/GradebookFilters/CourseGradeFilter/index.jsx
+++ b/src/components/GradebookFilters/CourseGradeFilter/index.jsx
@@ -3,8 +3,10 @@ import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
-import { ActionRow, Col, Button, Row } from '@edx/paragon';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
+import {
+  ActionRow, Col, Button, Row,
+} from '@edx/paragon';
 
 import selectors from 'data/selectors';
 import actions from 'data/actions';

--- a/src/components/GradebookFilters/CourseGradeFilter/index.jsx
+++ b/src/components/GradebookFilters/CourseGradeFilter/index.jsx
@@ -48,21 +48,25 @@ export class CourseGradeFilter extends React.Component {
     } = this.props;
     return (
       <>
-        <div className="grade-filter-inputs">
-          <PercentGroup
-            id="minimum-grade"
-            label={<FormattedMessage {...messages.minGrade} />}
-            value={courseGradeMin}
-            onChange={this.handleUpdateMin}
-          />
-          <PercentGroup
-            id="maximum-grade"
-            label={<FormattedMessage {...messages.maxGrade} />}
-            value={courseGradeMax}
-            onChange={this.handleUpdateMax}
-          />
+        <div className="row">
+          <div className="col-5">
+            <PercentGroup
+              id="minimum-grade"
+              label={<FormattedMessage {...messages.minGrade} />}
+              value={courseGradeMin}
+              onChange={this.handleUpdateMin}
+            />
+          </div>
+          <div className="col-5">
+            <PercentGroup
+              id="maximum-grade"
+              label={<FormattedMessage {...messages.maxGrade} />}
+              value={courseGradeMax}
+              onChange={this.handleUpdateMax}
+            />
+          </div>
         </div>
-        <div className="grade-filter-action">
+        <div className="text-right">
           <Button
             variant="outline-secondary"
             onClick={this.handleApplyClick}

--- a/src/components/GradebookFilters/CourseGradeFilter/test.jsx
+++ b/src/components/GradebookFilters/CourseGradeFilter/test.jsx
@@ -13,7 +13,10 @@ import {
 } from '.';
 
 jest.mock('@edx/paragon', () => ({
+  ActionRow: () => 'ActionRow',
+  Col: () => 'Col',
   Button: () => 'Button',
+  Row: () => 'Row',
 }));
 jest.mock('../PercentGroup', () => 'PercentGroup');
 

--- a/src/components/GradebookFilters/GradebookFilters.scss
+++ b/src/components/GradebookFilters/GradebookFilters.scss
@@ -1,6 +1,0 @@
-.filter-sidebar-header {
-    display: flex;
-    align-items: flex-start;
-    justify-content: space-between;
-    padding: 15px;
-}

--- a/src/components/GradebookFilters/PercentGroup.jsx
+++ b/src/components/GradebookFilters/PercentGroup.jsx
@@ -22,7 +22,7 @@ const PercentGroup = ({
         {...{ value, disabled, onChange }}
       />
     </Form.Group>
-    <span className="mr-2 mb-4 align-self-end">%</span>
+    <span className="mr-1 mb-4 align-self-end">%</span>
   </div>
 );
 PercentGroup.defaultProps = {

--- a/src/components/GradebookFilters/PercentGroup.jsx
+++ b/src/components/GradebookFilters/PercentGroup.jsx
@@ -11,7 +11,7 @@ const PercentGroup = ({
   disabled,
   onChange,
 }) => (
-  <div className="percent-group">
+  <div className="d-flex">
     <Form.Group controlId={id}>
       <Form.Label>{label}</Form.Label>
       <Form.Control
@@ -22,7 +22,7 @@ const PercentGroup = ({
         {...{ value, disabled, onChange }}
       />
     </Form.Group>
-    <span className="input-percent-label">%</span>
+    <span className="mr-2 mb-4 align-self-end">%</span>
   </div>
 );
 PercentGroup.defaultProps = {

--- a/src/components/GradebookFilters/SelectGroup.jsx
+++ b/src/components/GradebookFilters/SelectGroup.jsx
@@ -12,7 +12,7 @@ const SelectGroup = ({
   disabled,
   options,
 }) => (
-  <div className="student-filters">
+  <div>
     <Form.Group controlId={id}>
       <Form.Label>{label}</Form.Label>
       <Form.Control as="select" {...{ value, onChange, disabled }}>

--- a/src/components/GradebookFilters/__snapshots__/PercentGroup.test.jsx.snap
+++ b/src/components/GradebookFilters/__snapshots__/PercentGroup.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`PercentGroup Component snapshots basic snapshot 1`] = `
 <div
-  className="percent-group"
+  className="d-flex"
 >
   <FormGroup
     as="div"
@@ -28,7 +28,7 @@ exports[`PercentGroup Component snapshots basic snapshot 1`] = `
     />
   </FormGroup>
   <span
-    className="input-percent-label"
+    className="mr-1 mb-4 align-self-end"
   >
     %
   </span>
@@ -37,7 +37,7 @@ exports[`PercentGroup Component snapshots basic snapshot 1`] = `
 
 exports[`PercentGroup Component snapshots disabled 1`] = `
 <div
-  className="percent-group"
+  className="d-flex"
 >
   <FormGroup
     as="div"
@@ -63,7 +63,7 @@ exports[`PercentGroup Component snapshots disabled 1`] = `
     />
   </FormGroup>
   <span
-    className="input-percent-label"
+    className="mr-1 mb-4 align-self-end"
   >
     %
   </span>

--- a/src/components/GradebookFilters/__snapshots__/SelectGroup.test.jsx.snap
+++ b/src/components/GradebookFilters/__snapshots__/SelectGroup.test.jsx.snap
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SelectGroup Component snapshots basic snapshot 1`] = `
-<div
-  className="student-filters"
->
+<div>
   <FormGroup
     as="div"
     controlId="group id"
@@ -46,9 +44,7 @@ exports[`SelectGroup Component snapshots basic snapshot 1`] = `
 `;
 
 exports[`SelectGroup Component snapshots disabled 1`] = `
-<div
-  className="student-filters"
->
+<div>
   <FormGroup
     as="div"
     controlId="group id"

--- a/src/components/GradebookFilters/__snapshots__/test.jsx.snap
+++ b/src/components/GradebookFilters/__snapshots__/test.jsx.snap
@@ -3,7 +3,7 @@
 exports[`GradebookFilters Component snapshots basic snapshot 1`] = `
 <React.Fragment>
   <div
-    className="filter-sidebar-header"
+    className="d-flex align-items-start justify-content-between p-3"
   >
     <h2>
       <Icon

--- a/src/components/GradebookFilters/index.jsx
+++ b/src/components/GradebookFilters/index.jsx
@@ -57,7 +57,7 @@ export class GradebookFilters extends React.Component {
     } = this.props;
     return (
       <>
-        <div className="filter-sidebar-header">
+        <div className="d-flex align-items-start justify-content-between p-3">
           <h2><Icon className="fa fa-filter" /></h2>
           <IconButton
             className="p-1"

--- a/src/components/GradesView/EditModal/HistoryHeader.jsx
+++ b/src/components/GradesView/EditModal/HistoryHeader.jsx
@@ -10,7 +10,7 @@ import PropTypes from 'prop-types';
  */
 const HistoryHeader = ({ id, label, value }) => (
   <div>
-    <div className={`grade-history-header grade-history-${id}`}>{label}: </div>
+    <div className={`float-left grade-history-${id}`}>{label}: </div>
     <div>{value}</div>
   </div>
 );

--- a/src/components/GradesView/EditModal/HistoryHeader.jsx
+++ b/src/components/GradesView/EditModal/HistoryHeader.jsx
@@ -8,9 +8,9 @@ import PropTypes from 'prop-types';
  * @param {string} label - header label
  * @param {string} value - header value
  */
-const HistoryHeader = ({ id, label, value }) => (
-  <div>
-    <div className={`float-left grade-history-${id}`}>{label}: </div>
+const HistoryHeader = ({ label, value }) => (
+  <div className="row">
+    <div className="col-2">{label}: </div>
     <div>{value}</div>
   </div>
 );
@@ -18,7 +18,6 @@ HistoryHeader.defaultProps = {
   value: null,
 };
 HistoryHeader.propTypes = {
-  id: PropTypes.string.isRequired,
   label: PropTypes.node.isRequired,
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };

--- a/src/components/GradesView/EditModal/HistoryHeader.jsx
+++ b/src/components/GradesView/EditModal/HistoryHeader.jsx
@@ -8,9 +8,9 @@ import PropTypes from 'prop-types';
  * @param {string} label - header label
  * @param {string} value - header value
  */
-const HistoryHeader = ({ label, value }) => (
-  <div className="row">
-    <div className="col-2">{label}: </div>
+const HistoryHeader = ({ id, label, value }) => (
+  <div>
+    <div className={`float-left grade-history-${id}`}>{label}: </div>
     <div>{value}</div>
   </div>
 );
@@ -18,6 +18,7 @@ HistoryHeader.defaultProps = {
   value: null,
 };
 HistoryHeader.propTypes = {
+  id: PropTypes.string.isRequired,
   label: PropTypes.node.isRequired,
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };

--- a/src/components/GradesView/EditModal/HistoryHeader.test.jsx
+++ b/src/components/GradesView/EditModal/HistoryHeader.test.jsx
@@ -5,7 +5,6 @@ import HistoryHeader from './HistoryHeader';
 
 describe('HistoryHeader', () => {
   const props = {
-    id: 'water',
     label: 'Brita',
     value: 'hydration',
   };

--- a/src/components/GradesView/EditModal/HistoryHeader.test.jsx
+++ b/src/components/GradesView/EditModal/HistoryHeader.test.jsx
@@ -5,6 +5,7 @@ import HistoryHeader from './HistoryHeader';
 
 describe('HistoryHeader', () => {
   const props = {
+    id: 'water',
     label: 'Brita',
     value: 'hydration',
   };

--- a/src/components/GradesView/EditModal/ModalHeaders.jsx
+++ b/src/components/GradesView/EditModal/ModalHeaders.jsx
@@ -21,18 +21,22 @@ export const ModalHeaders = ({
 }) => (
   <div>
     <HistoryHeader
+      id="assignment"
       label={<FormattedMessage {...messages.assignmentHeader} />}
       value={modalState.assignmentName}
     />
     <HistoryHeader
+      id="student"
       label={<FormattedMessage {...messages.studentHeader} />}
       value={modalState.updateUserName}
     />
     <HistoryHeader
+      id="original-grade"
       label={<FormattedMessage {...messages.originalGradeHeader} />}
       value={originalGrade}
     />
     <HistoryHeader
+      id="current-grade"
       label={<FormattedMessage {...messages.currentGradeHeader} />}
       value={currentGrade}
     />

--- a/src/components/GradesView/EditModal/ModalHeaders.jsx
+++ b/src/components/GradesView/EditModal/ModalHeaders.jsx
@@ -21,22 +21,18 @@ export const ModalHeaders = ({
 }) => (
   <div>
     <HistoryHeader
-      id="assignment"
       label={<FormattedMessage {...messages.assignmentHeader} />}
       value={modalState.assignmentName}
     />
     <HistoryHeader
-      id="student"
       label={<FormattedMessage {...messages.studentHeader} />}
       value={modalState.updateUserName}
     />
     <HistoryHeader
-      id="original-grade"
       label={<FormattedMessage {...messages.originalGradeHeader} />}
       value={originalGrade}
     />
     <HistoryHeader
-      id="current-grade"
       label={<FormattedMessage {...messages.currentGradeHeader} />}
       value={currentGrade}
     />

--- a/src/components/GradesView/EditModal/__snapshots__/HistoryHeader.test.jsx.snap
+++ b/src/components/GradesView/EditModal/__snapshots__/HistoryHeader.test.jsx.snap
@@ -1,9 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`HistoryHeader Component snapshot 1`] = `
-<div>
+<div
+  className="row"
+>
   <div
-    className="float-left grade-history-water"
+    className="col-2"
   >
     Brita
     : 

--- a/src/components/GradesView/EditModal/__snapshots__/HistoryHeader.test.jsx.snap
+++ b/src/components/GradesView/EditModal/__snapshots__/HistoryHeader.test.jsx.snap
@@ -1,11 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`HistoryHeader Component snapshot 1`] = `
-<div
-  className="row"
->
+<div>
   <div
-    className="col-2"
+    className="float-left grade-history-water"
   >
     Brita
     : 

--- a/src/components/GradesView/EditModal/__snapshots__/HistoryHeader.test.jsx.snap
+++ b/src/components/GradesView/EditModal/__snapshots__/HistoryHeader.test.jsx.snap
@@ -3,7 +3,7 @@
 exports[`HistoryHeader Component snapshot 1`] = `
 <div>
   <div
-    className="grade-history-header grade-history-water"
+    className="float-left grade-history-water"
   >
     Brita
     : 

--- a/src/components/GradesView/EditModal/__snapshots__/ModalHeaders.test.jsx.snap
+++ b/src/components/GradesView/EditModal/__snapshots__/ModalHeaders.test.jsx.snap
@@ -3,6 +3,7 @@
 exports[`ModalHeaders Component snapshots gradeOverrideHistoryError is and empty and open is true modal open and StatusAlert showing 1`] = `
 <div>
   <HistoryHeader
+    id="assignment"
     label={
       <FormattedMessage
         defaultMessage="Assignment"
@@ -13,6 +14,7 @@ exports[`ModalHeaders Component snapshots gradeOverrideHistoryError is and empty
     value="Qwerty"
   />
   <HistoryHeader
+    id="student"
     label={
       <FormattedMessage
         defaultMessage="Student"
@@ -23,6 +25,7 @@ exports[`ModalHeaders Component snapshots gradeOverrideHistoryError is and empty
     value="Uiop"
   />
   <HistoryHeader
+    id="original-grade"
     label={
       <FormattedMessage
         defaultMessage="Original Grade"
@@ -33,6 +36,7 @@ exports[`ModalHeaders Component snapshots gradeOverrideHistoryError is and empty
     value={20}
   />
   <HistoryHeader
+    id="current-grade"
     label={
       <FormattedMessage
         defaultMessage="Current Grade"
@@ -48,6 +52,7 @@ exports[`ModalHeaders Component snapshots gradeOverrideHistoryError is and empty
 exports[`ModalHeaders Component snapshots gradeOverrideHistoryError is empty and open is false modal closed and StatusAlert closed 1`] = `
 <div>
   <HistoryHeader
+    id="assignment"
     label={
       <FormattedMessage
         defaultMessage="Assignment"
@@ -58,6 +63,7 @@ exports[`ModalHeaders Component snapshots gradeOverrideHistoryError is empty and
     value="Qwerty"
   />
   <HistoryHeader
+    id="student"
     label={
       <FormattedMessage
         defaultMessage="Student"
@@ -68,6 +74,7 @@ exports[`ModalHeaders Component snapshots gradeOverrideHistoryError is empty and
     value="Uiop"
   />
   <HistoryHeader
+    id="original-grade"
     label={
       <FormattedMessage
         defaultMessage="Original Grade"
@@ -78,6 +85,7 @@ exports[`ModalHeaders Component snapshots gradeOverrideHistoryError is empty and
     value={20}
   />
   <HistoryHeader
+    id="current-grade"
     label={
       <FormattedMessage
         defaultMessage="Current Grade"

--- a/src/components/GradesView/EditModal/__snapshots__/ModalHeaders.test.jsx.snap
+++ b/src/components/GradesView/EditModal/__snapshots__/ModalHeaders.test.jsx.snap
@@ -3,7 +3,6 @@
 exports[`ModalHeaders Component snapshots gradeOverrideHistoryError is and empty and open is true modal open and StatusAlert showing 1`] = `
 <div>
   <HistoryHeader
-    id="assignment"
     label={
       <FormattedMessage
         defaultMessage="Assignment"
@@ -14,7 +13,6 @@ exports[`ModalHeaders Component snapshots gradeOverrideHistoryError is and empty
     value="Qwerty"
   />
   <HistoryHeader
-    id="student"
     label={
       <FormattedMessage
         defaultMessage="Student"
@@ -25,7 +23,6 @@ exports[`ModalHeaders Component snapshots gradeOverrideHistoryError is and empty
     value="Uiop"
   />
   <HistoryHeader
-    id="original-grade"
     label={
       <FormattedMessage
         defaultMessage="Original Grade"
@@ -36,7 +33,6 @@ exports[`ModalHeaders Component snapshots gradeOverrideHistoryError is and empty
     value={20}
   />
   <HistoryHeader
-    id="current-grade"
     label={
       <FormattedMessage
         defaultMessage="Current Grade"
@@ -52,7 +48,6 @@ exports[`ModalHeaders Component snapshots gradeOverrideHistoryError is and empty
 exports[`ModalHeaders Component snapshots gradeOverrideHistoryError is empty and open is false modal closed and StatusAlert closed 1`] = `
 <div>
   <HistoryHeader
-    id="assignment"
     label={
       <FormattedMessage
         defaultMessage="Assignment"
@@ -63,7 +58,6 @@ exports[`ModalHeaders Component snapshots gradeOverrideHistoryError is empty and
     value="Qwerty"
   />
   <HistoryHeader
-    id="student"
     label={
       <FormattedMessage
         defaultMessage="Student"
@@ -74,7 +68,6 @@ exports[`ModalHeaders Component snapshots gradeOverrideHistoryError is empty and
     value="Uiop"
   />
   <HistoryHeader
-    id="original-grade"
     label={
       <FormattedMessage
         defaultMessage="Original Grade"
@@ -85,7 +78,6 @@ exports[`ModalHeaders Component snapshots gradeOverrideHistoryError is empty and
     value={20}
   />
   <HistoryHeader
-    id="current-grade"
     label={
       <FormattedMessage
         defaultMessage="Current Grade"

--- a/src/components/GradesView/GradebookTable/Fields.jsx
+++ b/src/components/GradesView/GradebookTable/Fields.jsx
@@ -12,7 +12,7 @@ import { StrictDict } from 'utils';
  */
 const Username = ({ username, userKey }) => (
   <div>
-    <span className="text-wrap">
+    <span className="text-break">
       <div>
         <div>{username}</div>
         {userKey && <div className="student-key">{userKey}</div>}
@@ -34,7 +34,7 @@ Username.propTypes = {
  * @param {string} email - email for display
  */
 const Email = ({ email }) => (
-  <span className="text-wrap">{email}</span>
+  <span className="text-break">{email}</span>
 );
 Email.propTypes = {
   email: PropTypes.string.isRequired,

--- a/src/components/GradesView/GradebookTable/Fields.jsx
+++ b/src/components/GradesView/GradebookTable/Fields.jsx
@@ -12,7 +12,7 @@ import { StrictDict } from 'utils';
  */
 const Username = ({ username, userKey }) => (
   <div>
-    <span className="wrap-text-in-cell">
+    <span className="text-wrap">
       <div>
         <div>{username}</div>
         {userKey && <div className="student-key">{userKey}</div>}
@@ -34,7 +34,7 @@ Username.propTypes = {
  * @param {string} email - email for display
  */
 const Email = ({ email }) => (
-  <span className="wrap-text-in-cell">{email}</span>
+  <span className="text-wrap">{email}</span>
 );
 Email.propTypes = {
   email: PropTypes.string.isRequired,

--- a/src/components/GradesView/GradebookTable/__snapshots__/Fields.test.jsx.snap
+++ b/src/components/GradesView/GradebookTable/__snapshots__/Fields.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Gradebook Table Fields Email snapshot 1`] = `
 <span
-  className="wrap-text-in-cell"
+  className="text-wrap"
 >
   myTag@place.com
 </span>
@@ -11,7 +11,7 @@ exports[`Gradebook Table Fields Email snapshot 1`] = `
 exports[`Gradebook Table Fields Username with external_user_key snapshot 1`] = `
 <div>
   <span
-    className="wrap-text-in-cell"
+    className="text-wrap"
   >
     <div>
       <div>
@@ -56,7 +56,7 @@ exports[`Gradebook Table Fields Username with external_user_key wraps external u
 exports[`Gradebook Table Fields Username without external_user_key snapshot 1`] = `
 <div>
   <span
-    className="wrap-text-in-cell"
+    className="text-wrap"
   >
     <div>
       <div>

--- a/src/components/GradesView/GradebookTable/__snapshots__/Fields.test.jsx.snap
+++ b/src/components/GradesView/GradebookTable/__snapshots__/Fields.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Gradebook Table Fields Email snapshot 1`] = `
 <span
-  className="text-wrap"
+  className="text-break"
 >
   myTag@place.com
 </span>
@@ -11,7 +11,7 @@ exports[`Gradebook Table Fields Email snapshot 1`] = `
 exports[`Gradebook Table Fields Username with external_user_key snapshot 1`] = `
 <div>
   <span
-    className="text-wrap"
+    className="text-break"
   >
     <div>
       <div>
@@ -56,7 +56,7 @@ exports[`Gradebook Table Fields Username with external_user_key wraps external u
 exports[`Gradebook Table Fields Username without external_user_key snapshot 1`] = `
 <div>
   <span
-    className="text-wrap"
+    className="text-break"
   >
     <div>
       <div>

--- a/src/components/GradesView/GradebookTable/__snapshots__/test.jsx.snap
+++ b/src/components/GradesView/GradebookTable/__snapshots__/test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`GradebookTable component snapshot - fields1 and 2 between email and totalGrade, mocked rows 1`] = `
 <div
-  className="gradebook-container w-100 position-relative overflow-auto"
+  className="gradebook-container shadow-sm w-100 position-relative overflow-auto"
 >
   <DataTable
     RowStatusComponent={[MockFunction this.nullMethod]}

--- a/src/components/GradesView/GradebookTable/__snapshots__/test.jsx.snap
+++ b/src/components/GradesView/GradebookTable/__snapshots__/test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`GradebookTable component snapshot - fields1 and 2 between email and totalGrade, mocked rows 1`] = `
 <div
-  className="gradebook-container"
+  className="gradebook-container w-100 position-relative overflow-auto"
 >
   <DataTable
     RowStatusComponent={[MockFunction this.nullMethod]}

--- a/src/components/GradesView/GradebookTable/index.jsx
+++ b/src/components/GradesView/GradebookTable/index.jsx
@@ -66,7 +66,7 @@ export class GradebookTable extends React.Component {
 
   render() {
     return (
-      <div className="gradebook-container w-100 position-relative overflow-auto">
+      <div className="gradebook-container shadow-sm w-100 position-relative overflow-auto">
         <DataTable
           columns={this.props.headings.map(this.mapHeaders)}
           data={this.props.grades.map(this.mapRows)}

--- a/src/components/GradesView/GradebookTable/index.jsx
+++ b/src/components/GradesView/GradebookTable/index.jsx
@@ -66,7 +66,7 @@ export class GradebookTable extends React.Component {
 
   render() {
     return (
-      <div className="gradebook-container">
+      <div className="gradebook-container w-100 position-relative overflow-auto">
         <DataTable
           columns={this.props.headings.map(this.mapHeaders)}
           data={this.props.grades.map(this.mapRows)}

--- a/src/components/GradesView/GradesView.scss
+++ b/src/components/GradesView/GradesView.scss
@@ -11,22 +11,6 @@
     width: 100vw;
 }
 
-.grade-history-assignment{
-    padding-right: 49px;
-}
-
-.grade-history-student{
-    padding-right: 75px;
-}
-
-.grade-history-original-grade{
-    padding-right: 25px;
-}
-
-.grade-history-current-grade{
-    padding-right: 25px;
-}
-
 .gradebook-container {
     max-height: 600px;
 }

--- a/src/components/GradesView/GradesView.scss
+++ b/src/components/GradesView/GradesView.scss
@@ -11,6 +11,22 @@
     width: 100vw;
 }
 
+.grade-history-assignment{
+    padding-right: 49px;
+}
+
+.grade-history-student{
+    padding-right: 75px;
+}
+
+.grade-history-original-grade{
+    padding-right: 25px;
+}
+
+.grade-history-current-grade{
+    padding-right: 25px;
+}
+
 .gradebook-container {
     max-height: 600px;
 }

--- a/src/components/GradesView/GradesView.scss
+++ b/src/components/GradesView/GradesView.scss
@@ -1,56 +1,20 @@
 .spinner-overlay {
-    position: fixed;
-    height: 100%;
-    width: 100%;
-    top: 0;
-    left: 0;
     background-color: #999;
     opacity: 0.5;
     z-index: 99999;
-    display:flex;
-    align-items: flex-start;
-    justify-content: center;
     padding: 200px;
-}
-
-.color-black {
-    color: black;
 }
 
 .gradebook-content {
     // note that this width isn't well-abstracted from Drawer code.
     // if we need to change it we may need to dig into those styles as well
     width: 100vw;
-    .search-help-text {
-        margin-left: 20px;
-    }
-    h4 {
-        font-weight: bold;
-        margin-top: 0rem;
-    }
-    .import-grades-btn {
-      margin-left: 20px;
-    }
-    .intervention-report-description {
-      margin-right: 40px;
-    }
-    h4.step-message-1 {
-      margin-top: 40px;
-    }
-}
-
-.student-filters{
-    .label{
-        padding-top: 30px;
-    }
-}
-.grade-history-header{
-    float: left;
 }
 
 .grade-history-assignment{
     padding-right: 49px;
 }
+
 .grade-history-student{
     padding-right: 75px;
 }
@@ -62,12 +26,9 @@
 .grade-history-current-grade{
     padding-right: 25px;
 }
+
 .gradebook-container {
-    width: 100%;
-    overflow-x: auto;
-    height: 600px;
-    overflow-y: auto;
-    position: relative;
+    max-height: 600px;
 }
 
 .form-group, .pgn__form-group {
@@ -76,37 +37,8 @@
   }
 }
 
-.filter-group {
-  .grade-filter-inputs {
-    .percent-group {
-      display: inline-block;
-      .form-group, .pgn__form-group {
-        width: 115px;
-        display: inline-block;
-      }
-      .input-percent-label {
-          margin-top: 22px;
-          margin-left: 5px;
-          margin-right: 5px;
-      }
-    }
-  }
-  .grade-filter-action {
-    text-align: right;
-  }
-}
-
-.mb-85 {
-    margin-bottom: 85px;
-}
-
 .modal-dialog {
     max-width: 1000px;
-}
-
-.wrap-text-in-cell {
-    overflow-wrap: break-word;
-    word-wrap: break-word;
 }
 
 select#ScoreView.form-control {
@@ -116,9 +48,10 @@ select#ScoreView.form-control {
 [dir=rtl] #course-grade-tooltip .arrow {
     right: initial;
     left: 0;
-    
+
     &:before {
         border-width: 0.4rem 0.4rem 0.4rem 0;
-        border-right-color: $black;
+        border-right-color: black;
+        border-right-color: var(--black);
     }
 }

--- a/src/components/GradesView/ImportGradesButton.jsx
+++ b/src/components/GradesView/ImportGradesButton.jsx
@@ -72,7 +72,7 @@ export class ImportGradesButton extends React.Component {
         </Form>
 
         <NetworkButton
-          className="import-grades-btn"
+          className="ml-4"
           label={messages.importGradesBtnText}
           onClick={this.handleClickImportGrades}
           import

--- a/src/components/GradesView/InterventionsReport.jsx
+++ b/src/components/GradesView/InterventionsReport.jsx
@@ -36,7 +36,7 @@ export class InterventionsReport extends React.Component {
         <div
           className="d-flex justify-content-between align-items-center"
         >
-          <div className="intervention-report-description">
+          <div className="mr-5">
             <FormattedMessage {...messages.description} />
           </div>
           <NetworkButton

--- a/src/components/GradesView/SearchControls.jsx
+++ b/src/components/GradesView/SearchControls.jsx
@@ -48,7 +48,7 @@ export class SearchControls extends React.Component {
           onClear={this.onClear}
           value={this.props.searchValue}
         />
-        <small className="form-text text-muted search-help-text">
+        <small className="form-text text-muted ml-4">
           <FormattedMessage {...messages.hint} />
         </small>
       </div>

--- a/src/components/GradesView/SpinnerIcon.jsx
+++ b/src/components/GradesView/SpinnerIcon.jsx
@@ -13,8 +13,8 @@ import selectors from 'data/selectors';
  * redux state says it should.
  */
 export const SpinnerIcon = ({ show }) => show && (
-  <div className="spinner-overlay">
-    <Icon className="fa fa-spinner fa-spin fa-5x color-black" />
+  <div className="spinner-overlay w-100 h-100 d-flex justify-content-center align-items-start fixed-top">
+    <Icon className="fa fa-spinner fa-spin fa-5x text-dark" />
   </div>
 );
 SpinnerIcon.defaultProps = {

--- a/src/components/GradesView/__snapshots__/ImportGradesButton.test.jsx.snap
+++ b/src/components/GradesView/__snapshots__/ImportGradesButton.test.jsx.snap
@@ -30,7 +30,7 @@ exports[`ImportGradesButton component snapshot snapshot - loads export form w/ a
     </FormGroup>
   </Form>
   <NetworkButton
-    className="import-grades-btn"
+    className="ml-4"
     import={true}
     label={
       Object {

--- a/src/components/GradesView/__snapshots__/InterventionsReport.test.jsx.snap
+++ b/src/components/GradesView/__snapshots__/InterventionsReport.test.jsx.snap
@@ -15,7 +15,7 @@ exports[`InterventionsReport component snapshots snapshot 1`] = `
     className="d-flex justify-content-between align-items-center"
   >
     <div
-      className="intervention-report-description"
+      className="mr-5"
     >
       <FormattedMessage
         defaultMessage="Need to find students who may be falling behind?  Download the interventions report to obtain engagement metrics such as section attempts and visits."

--- a/src/components/GradesView/__snapshots__/SearchControls.test.jsx.snap
+++ b/src/components/GradesView/__snapshots__/SearchControls.test.jsx.snap
@@ -16,7 +16,7 @@ exports[`SearchControls Component Snapshots basic snapshot 1`] = `
     value="alice"
   />
   <small
-    className="form-text text-muted search-help-text"
+    className="form-text text-muted ml-4"
   >
     <FormattedMessage
       defaultMessage="Search by username, email, or student key"

--- a/src/components/GradesView/__snapshots__/SpinnerIcon.test.jsx.snap
+++ b/src/components/GradesView/__snapshots__/SpinnerIcon.test.jsx.snap
@@ -2,10 +2,10 @@
 
 exports[`SpinnerIcon component snapshot - displays spinner overlay with spinner icon 1`] = `
 <div
-  className="spinner-overlay"
+  className="spinner-overlay w-100 h-100 d-flex justify-content-center align-items-start fixed-top"
 >
   <Icon
-    className="fa fa-spinner fa-spin fa-5x color-black"
+    className="fa fa-spinner fa-spin fa-5x text-dark"
   />
 </div>
 `;

--- a/src/components/GradesView/__snapshots__/test.jsx.snap
+++ b/src/components/GradesView/__snapshots__/test.jsx.snap
@@ -5,7 +5,7 @@ exports[`GradesView Component snapshots basic snapshot 1`] = `
   <SpinnerIcon />
   <InterventionsReport />
   <h4
-    className="step-message-1"
+    className="mt-5 font-weight-bold"
   >
     <FormattedMessage
       defaultMessage="Step 1: Filter the Grade Report"
@@ -23,7 +23,9 @@ exports[`GradesView Component snapshots basic snapshot 1`] = `
     handleClose={[MockFunction this.handleFilterBadgeClose]}
   />
   <StatusAlerts />
-  <h4>
+  <h4
+    className="font-weight-bold mt-0"
+  >
     <FormattedMessage
       defaultMessage="Step 2: View or Modify Individual Grades"
       description="Alert text for invalid minimum course grade"

--- a/src/components/GradesView/index.jsx
+++ b/src/components/GradesView/index.jsx
@@ -46,7 +46,7 @@ export class GradesView extends React.Component {
         <SpinnerIcon />
 
         <InterventionsReport />
-        <h4 className="step-message-1">
+        <h4 className="mt-5 font-weight-bold">
           <FormattedMessage {...messages.filterStepHeading} />
         </h4>
 
@@ -58,7 +58,7 @@ export class GradesView extends React.Component {
         <FilterBadges handleClose={this.handleFilterBadgeClose} />
         <StatusAlerts />
 
-        <h4><FormattedMessage {...messages.gradebookStepHeading} /></h4>
+        <h4 className="font-weight-bold mt-0"><FormattedMessage {...messages.gradebookStepHeading} /></h4>
 
         <div className="d-flex justify-content-between align-items-center mb-2">
           <ScoreViewInput />


### PR DESCRIPTION
**TL;DR -** Removes unnecessary custom scss classes and paragon variables and replaces with bootstrap classes.


**What changed?**

- Replaces custom scss with bootstrap classes wherever possible
- Removes use of paragon variables

**Screenshots**

Main screen **before**:
![before-main-screen](https://user-images.githubusercontent.com/10894099/187431264-86b495d7-2361-4a20-8fde-d30af8e9f525.png)
Main screen **after**: (Only change is use of `max-height` instead of `height` for table)
![after-main-screen](https://user-images.githubusercontent.com/10894099/187431310-416f5b03-233d-4693-905d-29316c2d558f.png)

Main screen drawer **before**:
![before-main-screen-open-drawer](https://user-images.githubusercontent.com/10894099/187431569-d83c19c2-b7bd-4e47-ab4c-792f59b838db.png)
Main screen drawer **after**:
![after-main-screen-open-drawer](https://user-images.githubusercontent.com/10894099/187431622-621729ca-470f-4da1-9773-cdff47a20bdd.png)

Bulk management **before**:
![before-bulk-screen](https://user-images.githubusercontent.com/10894099/187431838-6415817a-ffd1-437e-8448-96720cb03b83.png)
Bulk management **after**:
![after-bulk-screen](https://user-images.githubusercontent.com/10894099/187431880-d5829971-a6e9-4ef5-b0ab-f3cf7bac1231.png)

Modal **before**:
![before-modal](https://user-images.githubusercontent.com/10894099/187431949-a85ff25f-a2ef-4243-b13c-f580c7b5d4dd.png)
Modal **after**:

Here the Key value display is updated to use bootstrap grid instead of hacky spacing.
![after-modal](https://user-images.githubusercontent.com/10894099/187431981-ee6111ec-18b4-4a45-b991-4ff5e45b1246.png)
**Let me know if this looks acceptable**

**Developer Checklist**
- [x] Test suites passing
- [x] Documentation and test plan updated, if applicable
- [ ] Received code-owner approving review
- [ ] Bumped version number [package.json](../package.json)

**Testing Instructions**

Compare the look and feel of application before and after this PR.

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review
- [ ] I've tested the new functionality


FYI: @openedx/content-aurora
@edx/educator-neem
