### PR TITLE
RTL: fix (%) symbol to follow text direction

### DIFF
--- a/src/components/GradesView/GradebookTable/index.jsx
+++ b/src/components/GradesView/GradebookTable/index.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import { DataTable } from '@edx/paragon';
-import { FormattedMessage } from '@edx/frontend-platform/i18n';
+import { FormattedMessage, getLocale, isRtl } from '@edx/frontend-platform/i18n';
 
 import selectors from 'data/selectors';
 import { Headings } from 'data/constants/grades';
@@ -50,7 +50,7 @@ export class GradebookTable extends React.Component {
         <Fields.Username username={entry.username} userKey={entry.external_user_key} />
       ),
       [Headings.email]: (<Fields.Email email={entry.email} />),
-      [Headings.totalGrade]: `${roundGrade(entry.percent * 100)}%`,
+      [Headings.totalGrade]: `${roundGrade(entry.percent * 100)}${isRtl(getLocale()) ? '\u200f' : ''}%`,
     };
     entry.section_breakdown.forEach(subsection => {
       dataRow[subsection.label] = (


### PR DESCRIPTION
**TL;DR -** This commit makes the percentage (%) symbol appear correctly after numbers for RTL languages.

**Background**
- In RTL languages such as Arabic, the correct placement for `%` is to come after the number, following the writing direction
- For example, 25% in RTL should appear as %25 instead.

**What changed?**
- We use of 2 frontend-platform functions `isRtl` and `getLocale` to apply the fix only if the current user language is right-to-left.
- To avoid using a space to enforce the `%` to follow the RTL direction, we use instead the [right-to-left marker character](https://en.wikipedia.org/wiki/Right-to-left_mark) which is a non-printing character that does the exact job.
- This change is applied to the total grade column, which is the only occurrence in the project where a number is followed by `%`.

**Screenshots**
Look at the position of '%'
| LTR for reference | RTL before fix | RTL after fix |
| ---- | ---- | ---- |
| ![Screenshot from 2022-09-29 10-00-37](https://user-images.githubusercontent.com/10594967/192989806-3c201a28-c2fe-42b7-a22d-4cb30203e541.png) | ![Screenshot from 2022-09-29 09-59-56](https://user-images.githubusercontent.com/10594967/192989879-cc893a85-a4c2-427f-b492-a95914a80e71.png) | ![Screenshot from 2022-09-29 10-00-09](https://user-images.githubusercontent.com/10594967/192989954-087dcd22-a686-4b3b-84ed-ad7856cf16c8.png) |

**Developer Checklist**
- [x] Test suites passing
- [x] Documentation and test plan updated, if applicable
- [x] Received code-owner approving review

**Testing Instructions**
1. Change the platform language to an RTL language (eg Arabic)
2. Choose an existing course with at least one enrolled student, then access its gradebook app page.
3. In the gradebook table check the **Total Grade** row. It should print the `%` symbol on the left of the number. (eg. 25% should appear as %25)