### PR TITLE
RTL: use backslash to write fractions (grades)

### DIFF
--- a/src/components/GradesView/EditModal/OverrideTable/AdjustedGradeInput.jsx
+++ b/src/components/GradesView/EditModal/OverrideTable/AdjustedGradeInput.jsx
@@ -7,6 +7,7 @@ import { Form } from '@edx/paragon';
 
 import selectors from 'data/selectors';
 import actions from 'data/actions';
+import { getLocale, isRtl } from '@edx/frontend-platform/i18n';
 
 /**
  * <AdjustedGradeInput />
@@ -32,7 +33,7 @@ export class AdjustedGradeInput extends React.Component {
           value={this.props.value}
           onChange={this.onChange}
         />
-        {this.props.possibleGrade && ` / ${this.props.possibleGrade}`}
+        {this.props.possibleGrade && ` ${isRtl(getLocale()) ? '\\' : '/'} ${this.props.possibleGrade}`}
       </span>
     );
   }

--- a/src/data/selectors/grades.js
+++ b/src/data/selectors/grades.js
@@ -3,6 +3,7 @@ import { StrictDict } from 'utils';
 
 import { Headings, GradeFormats } from 'data/constants/grades';
 import { formatDateForDisplay } from 'data/actions/utils';
+import { getLocale, isRtl } from '@edx/frontend-platform/i18n';
 import simpleSelectorFactory from '../utils';
 import * as module from './grades';
 
@@ -156,7 +157,7 @@ export const subsectionGrade = StrictDict({
   [GradeFormats.absolute]: (subsection) => {
     const earned = module.roundGrade(subsection.score_earned);
     const possible = module.roundGrade(subsection.score_possible);
-    return subsection.attempted ? `${earned}/${possible}` : `${earned}`;
+    return subsection.attempted ? `${earned}${isRtl(getLocale()) ? '\\' : '/'}${possible}` : `${earned}`;
   },
   /**
    * subsectionGrade.percent(subsection)


### PR DESCRIPTION
**TL;DR -** This commit replaces the slash `/` for RTL languages with a backslash `\` when it is used to write fractions for such as `2/5` (grades)

**Background**
- In fractions, the direction of the slash determines which number comes on top (numerator) and which is on the bottom (denominator). For example: 3 / 2 means "2 over 3,  "2 divided by 3" or "2 out of 3"
- In RTL text, some characters are mirrored to match the writing direction, such as parentheses `( )` and comparison signs `< >`
- However, `/` is not mirrored in RTL, which introduces visual confusion when used to write fractions. For Example, **2 / 3** in English still shows as **2 / 3** in Arabic, while it should look **3 \ 2**

**What changed?**
- We use 2 frontend-platform functions `isRtl` and `getLocale` to apply the fix only if the current user language is right-to-left.
- we replace `/` with `\` for RTL languages in places where absolute grades are shown.
- The change is applied in the gradebook table when the score view is set to **absolute**, and in the **Edit grades modal > Adjusted grade column**

**Screenshots**
1. **Gradebook table with absolute score view**

| LTR for reference | RTL before fix | RTL after fix |
| ---- | ---- | ---- |
| ![Screenshot from 2022-09-29 11-42-09](https://user-images.githubusercontent.com/10594967/193012442-c128b1d8-1054-4e3b-b898-429328f4c85a.png) | ![Screenshot from 2022-09-29 11-44-11](https://user-images.githubusercontent.com/10594967/193012463-e898b30b-8c5e-4b68-9278-997ac52925a1.png) | ![Screenshot from 2022-09-29 11-42-48](https://user-images.githubusercontent.com/10594967/193012478-5e79d8d7-ce28-48cd-bf83-9c12d28425d4.png) |

2. **Adjusted grade input**
Look at the slash under the grade input field

| LTR for reference | ![Screenshot from 2022-09-29 11-47-16](https://user-images.githubusercontent.com/10594967/193013236-242e3414-783f-432b-84f5-1d4deab615ae.png) |
| --- | --- |
| RTL before fix | ![Screenshot from 2022-09-29 11-45-52](https://user-images.githubusercontent.com/10594967/193013310-4431e4af-f64c-47fd-b986-748860ae8619.png) |
| RTL after fix | ![Screenshot from 2022-09-29 11-46-18](https://user-images.githubusercontent.com/10594967/193013362-4a9db7dd-7cbe-4a44-b85d-d09605ed1bfa.png) |

**Developer Checklist**
- [x] Test suites passing
- [x] Documentation and test plan updated, if applicable
- [x] Received code-owner approving review

**Testing Instructions**
1. Change the platform language to an RTL language (eg Arabic)
5. Choose an existing course with at least one enrolled student, then access its gradebook app page.
6. Set the score view to **absolute**, then In the gradebook table check the grades are rendered with backslashes `\` instead of slashes `\`
7. In the **Edit grades modal > Adjusted grade column**, the possible grade should be preceded by a backslash.

FYI: @openedx/content-aurora
