### PR TITLE
fix: add an asterisk to the 'Email' name of column

### DIFF
--- a/src/components/GradesView/GradebookTable/__snapshots__/test.jsx.snap
+++ b/src/components/GradesView/GradebookTable/__snapshots__/test.jsx.snap
@@ -14,7 +14,7 @@ exports[`GradebookTable component snapshot - fields1 and 2 between email and tot
         },
         Object {
           "Header": <FormattedMessage
-            defaultMessage="Email"
+            defaultMessage="Email*"
             description="Gradebook table email column header"
             id="gradebook.GradesView.table.headings.email"
           />,

--- a/src/components/GradesView/GradebookTable/messages.js
+++ b/src/components/GradesView/GradebookTable/messages.js
@@ -3,7 +3,7 @@ import { defineMessages } from '@edx/frontend-platform/i18n';
 const messages = defineMessages({
   emailHeading: {
     id: 'gradebook.GradesView.table.headings.email',
-    defaultMessage: 'Email',
+    defaultMessage: 'Email*',
     description: 'Gradebook table email column header',
   },
   totalGradeHeading: {

--- a/src/i18n/messages/ar.json
+++ b/src/i18n/messages/ar.json
@@ -37,7 +37,7 @@
   "gradebook.GradesView.EditModal.Overrides.reasonHeader": "Reason",
   "gradebook.GradesTab.usersVisibilityLabel'": "Showing {filteredUsers} of {totalUsers} total learners",
   "gradebook.GradesView.editFilterLabel": "Edit Filters",
-  "gradebook.GradesView.table.headings.email": "Email",
+  "gradebook.GradesView.table.headings.email": "Email*",
   "gradebook.GradesView.table.headings.totalGrade": "Total Grade (%)",
   "gradebook.GradesView.table.headings.username": "Username",
   "gradebook.GradesView.table.labels.studentKey": "Student Key*",

--- a/src/i18n/messages/es_419.json
+++ b/src/i18n/messages/es_419.json
@@ -37,7 +37,7 @@
   "gradebook.GradesView.EditModal.Overrides.reasonHeader": "Reason",
   "gradebook.GradesTab.usersVisibilityLabel'": "Showing {filteredUsers} of {totalUsers} total learners",
   "gradebook.GradesView.editFilterLabel": "Edit Filters",
-  "gradebook.GradesView.table.headings.email": "Email",
+  "gradebook.GradesView.table.headings.email": "Email*",
   "gradebook.GradesView.table.headings.totalGrade": "Total Grade (%)",
   "gradebook.GradesView.table.headings.username": "Username",
   "gradebook.GradesView.table.labels.studentKey": "Student Key*",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -37,7 +37,7 @@
   "gradebook.GradesView.EditModal.Overrides.reasonHeader": "Motif",
   "gradebook.GradesTab.usersVisibilityLabel'": "Showing {filteredUsers} of {totalUsers} total learners",
   "gradebook.GradesView.editFilterLabel": "Editer les filtres",
-  "gradebook.GradesView.table.headings.email": "Email",
+  "gradebook.GradesView.table.headings.email": "Email*",
   "gradebook.GradesView.table.headings.totalGrade": "Note totale (%)",
   "gradebook.GradesView.table.headings.username": "Nom d’utilisateur",
   "gradebook.GradesView.table.labels.studentKey": "Clé d'étudiant",

--- a/src/i18n/messages/zh_CN.json
+++ b/src/i18n/messages/zh_CN.json
@@ -37,7 +37,7 @@
   "gradebook.GradesView.EditModal.Overrides.reasonHeader": "Reason",
   "gradebook.GradesTab.usersVisibilityLabel'": "Showing {filteredUsers} of {totalUsers} total learners",
   "gradebook.GradesView.editFilterLabel": "Edit Filters",
-  "gradebook.GradesView.table.headings.email": "Email",
+  "gradebook.GradesView.table.headings.email": "Email*",
   "gradebook.GradesView.table.headings.totalGrade": "Total Grade (%)",
   "gradebook.GradesView.table.headings.username": "Username",
   "gradebook.GradesView.table.labels.studentKey": "Student Key*",

--- a/src/i18n/transifex_input.json
+++ b/src/i18n/transifex_input.json
@@ -37,7 +37,7 @@
   "gradebook.GradesView.EditModal.Overrides.reasonHeader": "Reason",
   "gradebook.GradesTab.usersVisibilityLabel'": "Showing {filteredUsers} of {totalUsers} total learners",
   "gradebook.GradesView.editFilterLabel": "Edit Filters",
-  "gradebook.GradesView.table.headings.email": "Email",
+  "gradebook.GradesView.table.headings.email": "Email*",
   "gradebook.GradesView.table.headings.totalGrade": "Total Grade (%)",
   "gradebook.GradesView.table.headings.username": "Username",
   "gradebook.GradesView.table.labels.studentKey": "Student Key*",


### PR DESCRIPTION
**TL;DR** - I suggest adding the `*` sign to the email column name to identify that its data is available for masters track only (like for the "student key"). Because the [grades API code says](https://github.com/openedx/edx-platform/commit/68ec2e184d1b4ed7824954e34c97bef39647ebe2#diff-73ff878afa65080c863cd832be2d019b2882bd7c0544a45ecb26778757f7423dR155) that the data for that column only available for the masters mode.

<img width="887" alt="image" src="https://user-images.githubusercontent.com/17108583/193785500-5c4f5804-f8cc-4575-8c4d-38ec71634db7.png">