### PR TITLE
style: improve slash and percent sign i18n

### DIFF
--- a/src/components/GradesView/EditModal/OverrideTable/AdjustedGradeInput.jsx
+++ b/src/components/GradesView/EditModal/OverrideTable/AdjustedGradeInput.jsx
@@ -7,7 +7,7 @@ import { Form } from '@edx/paragon';
 
 import selectors from 'data/selectors';
 import actions from 'data/actions';
-import { getLocale, isRtl } from '@edx/frontend-platform/i18n';
+import { getLocalizedSlash } from 'i18n';
 
 /**
  * <AdjustedGradeInput />
@@ -33,7 +33,7 @@ export class AdjustedGradeInput extends React.Component {
           value={this.props.value}
           onChange={this.onChange}
         />
-        {this.props.possibleGrade && ` ${isRtl(getLocale()) ? '\\' : '/'} ${this.props.possibleGrade}`}
+        {this.props.possibleGrade && ` ${getLocalizedSlash()} ${this.props.possibleGrade}`}
       </span>
     );
   }

--- a/src/components/GradesView/GradebookTable/index.jsx
+++ b/src/components/GradesView/GradebookTable/index.jsx
@@ -4,12 +4,11 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import { DataTable } from '@edx/paragon';
-import {
-  FormattedMessage, getLocale, isRtl, injectIntl, intlShape,
-} from '@edx/frontend-platform/i18n';
+import { FormattedMessage, injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 
 import selectors from 'data/selectors';
 import { Headings } from 'data/constants/grades';
+import { getLocalizedPercentSign } from 'i18n';
 
 import messages from './messages';
 import Fields from './Fields';
@@ -51,7 +50,7 @@ export class GradebookTable extends React.Component {
       <Fields.Username username={entry.username} userKey={entry.external_user_key} />
     ),
     [Headings.email]: (<Fields.Email email={entry.email} />),
-    [Headings.totalGrade]: `${roundGrade(entry.percent * 100)}${isRtl(getLocale()) ? '\u200f' : ''}%`,
+    [Headings.totalGrade]: `${roundGrade(entry.percent * 100)}${getLocalizedPercentSign()}`,
     ...entry.section_breakdown.reduce((acc, subsection) => ({
       ...acc,
       [subsection.label]: <GradeButton {...{ entry, subsection }} />,

--- a/src/data/selectors/grades.js
+++ b/src/data/selectors/grades.js
@@ -3,7 +3,7 @@ import { StrictDict } from 'utils';
 
 import { Headings, GradeFormats } from 'data/constants/grades';
 import { formatDateForDisplay } from 'data/actions/utils';
-import { getLocale, isRtl } from '@edx/frontend-platform/i18n';
+import { getLocalizedSlash } from 'i18n';
 import simpleSelectorFactory from '../utils';
 import * as module from './grades';
 
@@ -157,7 +157,7 @@ export const subsectionGrade = StrictDict({
   [GradeFormats.absolute]: (subsection) => {
     const earned = module.roundGrade(subsection.score_earned);
     const possible = module.roundGrade(subsection.score_possible);
-    return subsection.attempted ? `${earned}${isRtl(getLocale()) ? '\\' : '/'}${possible}` : `${earned}`;
+    return subsection.attempted ? `${earned}${getLocalizedSlash()}${possible}` : `${earned}`;
   },
   /**
    * subsectionGrade.percent(subsection)

--- a/src/i18n/index.jsx
+++ b/src/i18n/index.jsx
@@ -1,3 +1,4 @@
+import { getLocale, isRtl } from '@edx/frontend-platform/i18n';
 import arMessages from './messages/ar.json';
 import deMessages from './messages/de.json';
 import es419Messages from './messages/es_419.json';
@@ -25,6 +26,27 @@ const messages = {
   'fr-ca': frCAMessages,
   ru: ruMessages,
   uk: ukMessages,
+};
+
+export const getLocalizedSlash = () => {
+  // For fractional grades
+  // if we are in a LTR language, we want to use a forward slash.
+  // If we are in a RTL language, we want to use a backslash instead
+  if (isRtl(getLocale())) {
+    return '\\';
+  }
+  return '/';
+};
+
+export const getLocalizedPercentSign = () => {
+  // LTR languages put the percent to the right of a number.
+  // RTL languages put the percent sign to the left of the number.
+  // We can place a non-printing unicode right-to-left marker next to the percent
+  // sign to make it print to the left of the number if we are currently in a LTR language
+  if (isRtl(getLocale())) {
+    return '\u200f%';
+  }
+  return '%';
 };
 
 export default messages;

--- a/src/i18n/index.test.jsx
+++ b/src/i18n/index.test.jsx
@@ -1,0 +1,29 @@
+import { isRtl } from '@edx/frontend-platform/i18n';
+import { getLocalizedSlash, getLocalizedPercentSign } from './index';
+
+jest.mock('@edx/frontend-platform/i18n', () => ({
+  isRtl: jest.fn(),
+  getLocale: jest.fn(),
+}));
+
+describe('getLocalizedSlash', () => {
+  it('ltr', () => {
+    isRtl.mockReturnValueOnce(false);
+    expect(getLocalizedSlash()).toEqual('/');
+  });
+  it('rtl', () => {
+    isRtl.mockReturnValueOnce(true);
+    expect(getLocalizedSlash()).toEqual('\\');
+  });
+});
+
+describe('getLocalizedPercentSign', () => {
+  it('ltr', () => {
+    isRtl.mockReturnValueOnce(false);
+    expect(getLocalizedPercentSign()).toEqual('%');
+  });
+  it('rtl', () => {
+    isRtl.mockReturnValueOnce(true);
+    expect(getLocalizedPercentSign()).toEqual('\u200f%');
+  });
+});


### PR DESCRIPTION
We had a PR recently that made some changes so stuff would display correctly in RTL languages. This pulls those out into helper functions so the code reads a bit cleaner, and adds comments explaining what we're doing and why 