### PR TITLE
fix: correct grades minmax values

### DIFF
--- a/src/data/selectors/index.js
+++ b/src/data/selectors/index.js
@@ -91,17 +91,10 @@ export const formattedGradeLimits = (state) => {
   const { assignmentGradeMax, assignmentGradeMin } = app.assignmentGradeLimits(state);
   const { courseGradeMax, courseGradeMin } = app.courseGradeLimits(state);
   const hasAssignment = filters.selectedAssignmentId(state) !== undefined;
-  if (!hasAssignment) {
-    return {
-      assignmentGradeMax: null,
-      assignmentGradeMin: null,
-      courseGradeMax: null,
-      courseGradeMin: null,
-    };
-  }
+
   return {
-    assignmentGradeMax: assignmentGradeMax === maxGrade ? null : assignmentGradeMax,
-    assignmentGradeMin: assignmentGradeMin === minGrade ? null : assignmentGradeMin,
+    assignmentGradeMax: (assignmentGradeMax === maxGrade || !hasAssignment) ? null : assignmentGradeMax,
+    assignmentGradeMin: (assignmentGradeMin === minGrade || !hasAssignment) ? null : assignmentGradeMin,
     courseGradeMax: courseGradeMax === maxGrade ? null : courseGradeMax,
     courseGradeMin: courseGradeMin === minGrade ? null : courseGradeMin,
   };

--- a/src/data/selectors/index.test.js
+++ b/src/data/selectors/index.test.js
@@ -260,15 +260,15 @@ describe('root selectors', () => {
     };
     const grade1 = '42';
     const grade2 = '3.14';
-    it('returns an object of nulls if assignment is not set', () => {
+    it('returns an object of nullable assignmentGrades if assignment is not set', () => {
       mockId(undefined);
       mockAssgn(grade1, grade2);
       mockCourse(grade1, grade2);
       expect(selector(testState)).toEqual({
         assignmentGradeMax: null,
         assignmentGradeMin: null,
-        courseGradeMax: null,
-        courseGradeMin: null,
+        courseGradeMax: '42',
+        courseGradeMin: '3.14',
       });
     });
     it('returns null for each extreme iff they are equal their default', () => {


### PR DESCRIPTION
### This is a backport of https://github.com/openedx/frontend-app-gradebook/pull/277

When the assignment type is selected, but the assignment id isn't - the courseGradeMax, courseGradeMin assignmentGradeMax and assignmentGradeMin values become nullable. This leads to incorrect filtering results.

The issue demo:
![gradebook_filters](https://user-images.githubusercontent.com/47273130/195368475-796db248-df43-4940-b6c0-bb525de8b3b6.gif)

Fix:
- Preserve the courseGradeMax and courseGradeMin values in such cases;

The fix demo:
![gradebook_filters_fix](https://user-images.githubusercontent.com/47273130/195368551-12201b2a-a801-4d53-a2c6-f1a37c038c4a.gif)


