### PR TITLE
feat: remove util as a dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,6 @@
         "redux-thunk": "2.3.0",
         "regenerator-runtime": "^0.13.7",
         "sass": "^1.49.0",
-        "util": "^0.12.3",
         "whatwg-fetch": "^2.0.4"
       },
       "devDependencies": {
@@ -4138,9 +4137,9 @@
       }
     },
     "node_modules/@jest/console/node_modules/@types/yargs": {
-      "version": "17.0.19",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.19.tgz",
-      "integrity": "sha512-cAx3qamwaYX9R0fzOIZAlFpo4A+1uBVCxqpKz9D26uTF4srRXaGTTsikQmaotCtNdbhzyUH7ft6p9ktz9s6UNQ==",
+      "version": "17.0.20",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.20.tgz",
+      "integrity": "sha512-eknWrTHofQuPk2iuqDm1waA7V6xPlbgBoaaXEgYkClhLOnB0TtbW+srJaOToAgawPxPlHQzwypFA2bhZaUGP5A==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -4348,9 +4347,9 @@
       }
     },
     "node_modules/@jest/core/node_modules/@types/yargs": {
-      "version": "17.0.19",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.19.tgz",
-      "integrity": "sha512-cAx3qamwaYX9R0fzOIZAlFpo4A+1uBVCxqpKz9D26uTF4srRXaGTTsikQmaotCtNdbhzyUH7ft6p9ktz9s6UNQ==",
+      "version": "17.0.20",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.20.tgz",
+      "integrity": "sha512-eknWrTHofQuPk2iuqDm1waA7V6xPlbgBoaaXEgYkClhLOnB0TtbW+srJaOToAgawPxPlHQzwypFA2bhZaUGP5A==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -4553,9 +4552,9 @@
       }
     },
     "node_modules/@jest/environment/node_modules/@types/yargs": {
-      "version": "17.0.19",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.19.tgz",
-      "integrity": "sha512-cAx3qamwaYX9R0fzOIZAlFpo4A+1uBVCxqpKz9D26uTF4srRXaGTTsikQmaotCtNdbhzyUH7ft6p9ktz9s6UNQ==",
+      "version": "17.0.20",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.20.tgz",
+      "integrity": "sha512-eknWrTHofQuPk2iuqDm1waA7V6xPlbgBoaaXEgYkClhLOnB0TtbW+srJaOToAgawPxPlHQzwypFA2bhZaUGP5A==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -4700,9 +4699,9 @@
       }
     },
     "node_modules/@jest/fake-timers/node_modules/@types/yargs": {
-      "version": "17.0.19",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.19.tgz",
-      "integrity": "sha512-cAx3qamwaYX9R0fzOIZAlFpo4A+1uBVCxqpKz9D26uTF4srRXaGTTsikQmaotCtNdbhzyUH7ft6p9ktz9s6UNQ==",
+      "version": "17.0.20",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.20.tgz",
+      "integrity": "sha512-eknWrTHofQuPk2iuqDm1waA7V6xPlbgBoaaXEgYkClhLOnB0TtbW+srJaOToAgawPxPlHQzwypFA2bhZaUGP5A==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -5147,9 +5146,9 @@
       }
     },
     "node_modules/@jest/reporters/node_modules/@types/yargs": {
-      "version": "17.0.19",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.19.tgz",
-      "integrity": "sha512-cAx3qamwaYX9R0fzOIZAlFpo4A+1uBVCxqpKz9D26uTF4srRXaGTTsikQmaotCtNdbhzyUH7ft6p9ktz9s6UNQ==",
+      "version": "17.0.20",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.20.tgz",
+      "integrity": "sha512-eknWrTHofQuPk2iuqDm1waA7V6xPlbgBoaaXEgYkClhLOnB0TtbW+srJaOToAgawPxPlHQzwypFA2bhZaUGP5A==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -5386,9 +5385,9 @@
       }
     },
     "node_modules/@jest/test-result/node_modules/@types/yargs": {
-      "version": "17.0.19",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.19.tgz",
-      "integrity": "sha512-cAx3qamwaYX9R0fzOIZAlFpo4A+1uBVCxqpKz9D26uTF4srRXaGTTsikQmaotCtNdbhzyUH7ft6p9ktz9s6UNQ==",
+      "version": "17.0.20",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.20.tgz",
+      "integrity": "sha512-eknWrTHofQuPk2iuqDm1waA7V6xPlbgBoaaXEgYkClhLOnB0TtbW+srJaOToAgawPxPlHQzwypFA2bhZaUGP5A==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -5497,9 +5496,9 @@
       }
     },
     "node_modules/@jest/test-sequencer/node_modules/@types/yargs": {
-      "version": "17.0.19",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.19.tgz",
-      "integrity": "sha512-cAx3qamwaYX9R0fzOIZAlFpo4A+1uBVCxqpKz9D26uTF4srRXaGTTsikQmaotCtNdbhzyUH7ft6p9ktz9s6UNQ==",
+      "version": "17.0.20",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.20.tgz",
+      "integrity": "sha512-eknWrTHofQuPk2iuqDm1waA7V6xPlbgBoaaXEgYkClhLOnB0TtbW+srJaOToAgawPxPlHQzwypFA2bhZaUGP5A==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -12573,9 +12572,9 @@
       }
     },
     "node_modules/expect/node_modules/@types/yargs": {
-      "version": "17.0.19",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.19.tgz",
-      "integrity": "sha512-cAx3qamwaYX9R0fzOIZAlFpo4A+1uBVCxqpKz9D26uTF4srRXaGTTsikQmaotCtNdbhzyUH7ft6p9ktz9s6UNQ==",
+      "version": "17.0.20",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.20.tgz",
+      "integrity": "sha512-eknWrTHofQuPk2iuqDm1waA7V6xPlbgBoaaXEgYkClhLOnB0TtbW+srJaOToAgawPxPlHQzwypFA2bhZaUGP5A==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -14897,6 +14896,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
       "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -15148,20 +15148,6 @@
       "dev": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/is-generator-function": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
-      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
-      "dependencies": {
-        "has-tostringtag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-glob": {
@@ -15834,9 +15820,9 @@
       }
     },
     "node_modules/jest-circus/node_modules/@types/yargs": {
-      "version": "17.0.19",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.19.tgz",
-      "integrity": "sha512-cAx3qamwaYX9R0fzOIZAlFpo4A+1uBVCxqpKz9D26uTF4srRXaGTTsikQmaotCtNdbhzyUH7ft6p9ktz9s6UNQ==",
+      "version": "17.0.20",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.20.tgz",
+      "integrity": "sha512-eknWrTHofQuPk2iuqDm1waA7V6xPlbgBoaaXEgYkClhLOnB0TtbW+srJaOToAgawPxPlHQzwypFA2bhZaUGP5A==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -16005,9 +15991,9 @@
       }
     },
     "node_modules/jest-cli/node_modules/@types/yargs": {
-      "version": "17.0.19",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.19.tgz",
-      "integrity": "sha512-cAx3qamwaYX9R0fzOIZAlFpo4A+1uBVCxqpKz9D26uTF4srRXaGTTsikQmaotCtNdbhzyUH7ft6p9ktz9s6UNQ==",
+      "version": "17.0.20",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.20.tgz",
+      "integrity": "sha512-eknWrTHofQuPk2iuqDm1waA7V6xPlbgBoaaXEgYkClhLOnB0TtbW+srJaOToAgawPxPlHQzwypFA2bhZaUGP5A==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -16268,9 +16254,9 @@
       }
     },
     "node_modules/jest-config/node_modules/@types/yargs": {
-      "version": "17.0.19",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.19.tgz",
-      "integrity": "sha512-cAx3qamwaYX9R0fzOIZAlFpo4A+1uBVCxqpKz9D26uTF4srRXaGTTsikQmaotCtNdbhzyUH7ft6p9ktz9s6UNQ==",
+      "version": "17.0.20",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.20.tgz",
+      "integrity": "sha512-eknWrTHofQuPk2iuqDm1waA7V6xPlbgBoaaXEgYkClhLOnB0TtbW+srJaOToAgawPxPlHQzwypFA2bhZaUGP5A==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -16623,9 +16609,9 @@
       }
     },
     "node_modules/jest-each/node_modules/@types/yargs": {
-      "version": "17.0.19",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.19.tgz",
-      "integrity": "sha512-cAx3qamwaYX9R0fzOIZAlFpo4A+1uBVCxqpKz9D26uTF4srRXaGTTsikQmaotCtNdbhzyUH7ft6p9ktz9s6UNQ==",
+      "version": "17.0.20",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.20.tgz",
+      "integrity": "sha512-eknWrTHofQuPk2iuqDm1waA7V6xPlbgBoaaXEgYkClhLOnB0TtbW+srJaOToAgawPxPlHQzwypFA2bhZaUGP5A==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -16768,9 +16754,9 @@
       }
     },
     "node_modules/jest-environment-node/node_modules/@types/yargs": {
-      "version": "17.0.19",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.19.tgz",
-      "integrity": "sha512-cAx3qamwaYX9R0fzOIZAlFpo4A+1uBVCxqpKz9D26uTF4srRXaGTTsikQmaotCtNdbhzyUH7ft6p9ktz9s6UNQ==",
+      "version": "17.0.20",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.20.tgz",
+      "integrity": "sha512-eknWrTHofQuPk2iuqDm1waA7V6xPlbgBoaaXEgYkClhLOnB0TtbW+srJaOToAgawPxPlHQzwypFA2bhZaUGP5A==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -17085,9 +17071,9 @@
       }
     },
     "node_modules/jest-message-util/node_modules/@types/yargs": {
-      "version": "17.0.19",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.19.tgz",
-      "integrity": "sha512-cAx3qamwaYX9R0fzOIZAlFpo4A+1uBVCxqpKz9D26uTF4srRXaGTTsikQmaotCtNdbhzyUH7ft6p9ktz9s6UNQ==",
+      "version": "17.0.20",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.20.tgz",
+      "integrity": "sha512-eknWrTHofQuPk2iuqDm1waA7V6xPlbgBoaaXEgYkClhLOnB0TtbW+srJaOToAgawPxPlHQzwypFA2bhZaUGP5A==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -17204,9 +17190,9 @@
       }
     },
     "node_modules/jest-mock/node_modules/@types/yargs": {
-      "version": "17.0.19",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.19.tgz",
-      "integrity": "sha512-cAx3qamwaYX9R0fzOIZAlFpo4A+1uBVCxqpKz9D26uTF4srRXaGTTsikQmaotCtNdbhzyUH7ft6p9ktz9s6UNQ==",
+      "version": "17.0.20",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.20.tgz",
+      "integrity": "sha512-eknWrTHofQuPk2iuqDm1waA7V6xPlbgBoaaXEgYkClhLOnB0TtbW+srJaOToAgawPxPlHQzwypFA2bhZaUGP5A==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -17400,9 +17386,9 @@
       }
     },
     "node_modules/jest-resolve/node_modules/@types/yargs": {
-      "version": "17.0.19",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.19.tgz",
-      "integrity": "sha512-cAx3qamwaYX9R0fzOIZAlFpo4A+1uBVCxqpKz9D26uTF4srRXaGTTsikQmaotCtNdbhzyUH7ft6p9ktz9s6UNQ==",
+      "version": "17.0.20",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.20.tgz",
+      "integrity": "sha512-eknWrTHofQuPk2iuqDm1waA7V6xPlbgBoaaXEgYkClhLOnB0TtbW+srJaOToAgawPxPlHQzwypFA2bhZaUGP5A==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -17629,9 +17615,9 @@
       }
     },
     "node_modules/jest-runner/node_modules/@types/yargs": {
-      "version": "17.0.19",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.19.tgz",
-      "integrity": "sha512-cAx3qamwaYX9R0fzOIZAlFpo4A+1uBVCxqpKz9D26uTF4srRXaGTTsikQmaotCtNdbhzyUH7ft6p9ktz9s6UNQ==",
+      "version": "17.0.20",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.20.tgz",
+      "integrity": "sha512-eknWrTHofQuPk2iuqDm1waA7V6xPlbgBoaaXEgYkClhLOnB0TtbW+srJaOToAgawPxPlHQzwypFA2bhZaUGP5A==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -17924,9 +17910,9 @@
       }
     },
     "node_modules/jest-runtime/node_modules/@types/yargs": {
-      "version": "17.0.19",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.19.tgz",
-      "integrity": "sha512-cAx3qamwaYX9R0fzOIZAlFpo4A+1uBVCxqpKz9D26uTF4srRXaGTTsikQmaotCtNdbhzyUH7ft6p9ktz9s6UNQ==",
+      "version": "17.0.20",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.20.tgz",
+      "integrity": "sha512-eknWrTHofQuPk2iuqDm1waA7V6xPlbgBoaaXEgYkClhLOnB0TtbW+srJaOToAgawPxPlHQzwypFA2bhZaUGP5A==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -18203,9 +18189,9 @@
       }
     },
     "node_modules/jest-snapshot/node_modules/@types/yargs": {
-      "version": "17.0.19",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.19.tgz",
-      "integrity": "sha512-cAx3qamwaYX9R0fzOIZAlFpo4A+1uBVCxqpKz9D26uTF4srRXaGTTsikQmaotCtNdbhzyUH7ft6p9ktz9s6UNQ==",
+      "version": "17.0.20",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.20.tgz",
+      "integrity": "sha512-eknWrTHofQuPk2iuqDm1waA7V6xPlbgBoaaXEgYkClhLOnB0TtbW+srJaOToAgawPxPlHQzwypFA2bhZaUGP5A==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -18524,9 +18510,9 @@
       }
     },
     "node_modules/jest-validate/node_modules/@types/yargs": {
-      "version": "17.0.19",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.19.tgz",
-      "integrity": "sha512-cAx3qamwaYX9R0fzOIZAlFpo4A+1uBVCxqpKz9D26uTF4srRXaGTTsikQmaotCtNdbhzyUH7ft6p9ktz9s6UNQ==",
+      "version": "17.0.20",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.20.tgz",
+      "integrity": "sha512-eknWrTHofQuPk2iuqDm1waA7V6xPlbgBoaaXEgYkClhLOnB0TtbW+srJaOToAgawPxPlHQzwypFA2bhZaUGP5A==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -18639,9 +18625,9 @@
       }
     },
     "node_modules/jest-watcher/node_modules/@types/yargs": {
-      "version": "17.0.19",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.19.tgz",
-      "integrity": "sha512-cAx3qamwaYX9R0fzOIZAlFpo4A+1uBVCxqpKz9D26uTF4srRXaGTTsikQmaotCtNdbhzyUH7ft6p9ktz9s6UNQ==",
+      "version": "17.0.20",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.20.tgz",
+      "integrity": "sha512-eknWrTHofQuPk2iuqDm1waA7V6xPlbgBoaaXEgYkClhLOnB0TtbW+srJaOToAgawPxPlHQzwypFA2bhZaUGP5A==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -18794,9 +18780,9 @@
       }
     },
     "node_modules/jest-worker/node_modules/@types/yargs": {
-      "version": "17.0.19",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.19.tgz",
-      "integrity": "sha512-cAx3qamwaYX9R0fzOIZAlFpo4A+1uBVCxqpKz9D26uTF4srRXaGTTsikQmaotCtNdbhzyUH7ft6p9ktz9s6UNQ==",
+      "version": "17.0.20",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.20.tgz",
+      "integrity": "sha512-eknWrTHofQuPk2iuqDm1waA7V6xPlbgBoaaXEgYkClhLOnB0TtbW+srJaOToAgawPxPlHQzwypFA2bhZaUGP5A==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -18937,9 +18923,9 @@
       }
     },
     "node_modules/jest/node_modules/@types/yargs": {
-      "version": "17.0.19",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.19.tgz",
-      "integrity": "sha512-cAx3qamwaYX9R0fzOIZAlFpo4A+1uBVCxqpKz9D26uTF4srRXaGTTsikQmaotCtNdbhzyUH7ft6p9ktz9s6UNQ==",
+      "version": "17.0.20",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.20.tgz",
+      "integrity": "sha512-eknWrTHofQuPk2iuqDm1waA7V6xPlbgBoaaXEgYkClhLOnB0TtbW+srJaOToAgawPxPlHQzwypFA2bhZaUGP5A==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -26021,9 +26007,9 @@
       }
     },
     "node_modules/resolve.exports": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-1.1.0.tgz",
-      "integrity": "sha512-J1l+Zxxp4XK3LUDZ9m60LRJF/mAe4z6a4xyabPHk7pvK5t35dACV32iIjJDFeWZFfZlO29w6SZ67knR0tHzJtQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-1.1.1.tgz",
+      "integrity": "sha512-/NtpHNDN7jWhAaQ9BvBUYZ6YTXsRBgfqWFWP7BZBaoMJO/I3G5OFzvTuWNlZC3aPjins1F+TNrLKsGbH4rfsRQ==",
       "dev": true,
       "engines": {
         "node": ">=10"
@@ -26154,7 +26140,8 @@
     "node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
     },
     "node_modules/safe-regex": {
       "version": "1.1.0",
@@ -29397,19 +29384,6 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/util": {
-      "version": "0.12.4",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
-      "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "is-arguments": "^1.0.4",
-        "is-generator-function": "^1.0.7",
-        "is-typed-array": "^1.1.3",
-        "safe-buffer": "^5.1.2",
-        "which-typed-array": "^1.1.2"
-      }
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
@@ -33633,9 +33607,9 @@
           }
         },
         "@types/yargs": {
-          "version": "17.0.19",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.19.tgz",
-          "integrity": "sha512-cAx3qamwaYX9R0fzOIZAlFpo4A+1uBVCxqpKz9D26uTF4srRXaGTTsikQmaotCtNdbhzyUH7ft6p9ktz9s6UNQ==",
+          "version": "17.0.20",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.20.tgz",
+          "integrity": "sha512-eknWrTHofQuPk2iuqDm1waA7V6xPlbgBoaaXEgYkClhLOnB0TtbW+srJaOToAgawPxPlHQzwypFA2bhZaUGP5A==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -33792,9 +33766,9 @@
           }
         },
         "@types/yargs": {
-          "version": "17.0.19",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.19.tgz",
-          "integrity": "sha512-cAx3qamwaYX9R0fzOIZAlFpo4A+1uBVCxqpKz9D26uTF4srRXaGTTsikQmaotCtNdbhzyUH7ft6p9ktz9s6UNQ==",
+          "version": "17.0.20",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.20.tgz",
+          "integrity": "sha512-eknWrTHofQuPk2iuqDm1waA7V6xPlbgBoaaXEgYkClhLOnB0TtbW+srJaOToAgawPxPlHQzwypFA2bhZaUGP5A==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -33946,9 +33920,9 @@
           }
         },
         "@types/yargs": {
-          "version": "17.0.19",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.19.tgz",
-          "integrity": "sha512-cAx3qamwaYX9R0fzOIZAlFpo4A+1uBVCxqpKz9D26uTF4srRXaGTTsikQmaotCtNdbhzyUH7ft6p9ktz9s6UNQ==",
+          "version": "17.0.20",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.20.tgz",
+          "integrity": "sha512-eknWrTHofQuPk2iuqDm1waA7V6xPlbgBoaaXEgYkClhLOnB0TtbW+srJaOToAgawPxPlHQzwypFA2bhZaUGP5A==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -34062,9 +34036,9 @@
           }
         },
         "@types/yargs": {
-          "version": "17.0.19",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.19.tgz",
-          "integrity": "sha512-cAx3qamwaYX9R0fzOIZAlFpo4A+1uBVCxqpKz9D26uTF4srRXaGTTsikQmaotCtNdbhzyUH7ft6p9ktz9s6UNQ==",
+          "version": "17.0.20",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.20.tgz",
+          "integrity": "sha512-eknWrTHofQuPk2iuqDm1waA7V6xPlbgBoaaXEgYkClhLOnB0TtbW+srJaOToAgawPxPlHQzwypFA2bhZaUGP5A==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -34408,9 +34382,9 @@
           }
         },
         "@types/yargs": {
-          "version": "17.0.19",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.19.tgz",
-          "integrity": "sha512-cAx3qamwaYX9R0fzOIZAlFpo4A+1uBVCxqpKz9D26uTF4srRXaGTTsikQmaotCtNdbhzyUH7ft6p9ktz9s6UNQ==",
+          "version": "17.0.20",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.20.tgz",
+          "integrity": "sha512-eknWrTHofQuPk2iuqDm1waA7V6xPlbgBoaaXEgYkClhLOnB0TtbW+srJaOToAgawPxPlHQzwypFA2bhZaUGP5A==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -34587,9 +34561,9 @@
           }
         },
         "@types/yargs": {
-          "version": "17.0.19",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.19.tgz",
-          "integrity": "sha512-cAx3qamwaYX9R0fzOIZAlFpo4A+1uBVCxqpKz9D26uTF4srRXaGTTsikQmaotCtNdbhzyUH7ft6p9ktz9s6UNQ==",
+          "version": "17.0.20",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.20.tgz",
+          "integrity": "sha512-eknWrTHofQuPk2iuqDm1waA7V6xPlbgBoaaXEgYkClhLOnB0TtbW+srJaOToAgawPxPlHQzwypFA2bhZaUGP5A==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -34673,9 +34647,9 @@
           }
         },
         "@types/yargs": {
-          "version": "17.0.19",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.19.tgz",
-          "integrity": "sha512-cAx3qamwaYX9R0fzOIZAlFpo4A+1uBVCxqpKz9D26uTF4srRXaGTTsikQmaotCtNdbhzyUH7ft6p9ktz9s6UNQ==",
+          "version": "17.0.20",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.20.tgz",
+          "integrity": "sha512-eknWrTHofQuPk2iuqDm1waA7V6xPlbgBoaaXEgYkClhLOnB0TtbW+srJaOToAgawPxPlHQzwypFA2bhZaUGP5A==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -40110,9 +40084,9 @@
           }
         },
         "@types/yargs": {
-          "version": "17.0.19",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.19.tgz",
-          "integrity": "sha512-cAx3qamwaYX9R0fzOIZAlFpo4A+1uBVCxqpKz9D26uTF4srRXaGTTsikQmaotCtNdbhzyUH7ft6p9ktz9s6UNQ==",
+          "version": "17.0.20",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.20.tgz",
+          "integrity": "sha512-eknWrTHofQuPk2iuqDm1waA7V6xPlbgBoaaXEgYkClhLOnB0TtbW+srJaOToAgawPxPlHQzwypFA2bhZaUGP5A==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -41824,6 +41798,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
       "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -41983,14 +41958,6 @@
       "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
       "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
       "dev": true
-    },
-    "is-generator-function": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
-      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
-      "requires": {
-        "has-tostringtag": "^1.0.0"
-      }
     },
     "is-glob": {
       "version": "4.0.3",
@@ -42352,9 +42319,9 @@
           }
         },
         "@types/yargs": {
-          "version": "17.0.19",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.19.tgz",
-          "integrity": "sha512-cAx3qamwaYX9R0fzOIZAlFpo4A+1uBVCxqpKz9D26uTF4srRXaGTTsikQmaotCtNdbhzyUH7ft6p9ktz9s6UNQ==",
+          "version": "17.0.20",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.20.tgz",
+          "integrity": "sha512-eknWrTHofQuPk2iuqDm1waA7V6xPlbgBoaaXEgYkClhLOnB0TtbW+srJaOToAgawPxPlHQzwypFA2bhZaUGP5A==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -42550,9 +42517,9 @@
           }
         },
         "@types/yargs": {
-          "version": "17.0.19",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.19.tgz",
-          "integrity": "sha512-cAx3qamwaYX9R0fzOIZAlFpo4A+1uBVCxqpKz9D26uTF4srRXaGTTsikQmaotCtNdbhzyUH7ft6p9ktz9s6UNQ==",
+          "version": "17.0.20",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.20.tgz",
+          "integrity": "sha512-eknWrTHofQuPk2iuqDm1waA7V6xPlbgBoaaXEgYkClhLOnB0TtbW+srJaOToAgawPxPlHQzwypFA2bhZaUGP5A==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -42670,9 +42637,9 @@
           }
         },
         "@types/yargs": {
-          "version": "17.0.19",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.19.tgz",
-          "integrity": "sha512-cAx3qamwaYX9R0fzOIZAlFpo4A+1uBVCxqpKz9D26uTF4srRXaGTTsikQmaotCtNdbhzyUH7ft6p9ktz9s6UNQ==",
+          "version": "17.0.20",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.20.tgz",
+          "integrity": "sha512-eknWrTHofQuPk2iuqDm1waA7V6xPlbgBoaaXEgYkClhLOnB0TtbW+srJaOToAgawPxPlHQzwypFA2bhZaUGP5A==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -42866,9 +42833,9 @@
           }
         },
         "@types/yargs": {
-          "version": "17.0.19",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.19.tgz",
-          "integrity": "sha512-cAx3qamwaYX9R0fzOIZAlFpo4A+1uBVCxqpKz9D26uTF4srRXaGTTsikQmaotCtNdbhzyUH7ft6p9ktz9s6UNQ==",
+          "version": "17.0.20",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.20.tgz",
+          "integrity": "sha512-eknWrTHofQuPk2iuqDm1waA7V6xPlbgBoaaXEgYkClhLOnB0TtbW+srJaOToAgawPxPlHQzwypFA2bhZaUGP5A==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -43130,9 +43097,9 @@
           }
         },
         "@types/yargs": {
-          "version": "17.0.19",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.19.tgz",
-          "integrity": "sha512-cAx3qamwaYX9R0fzOIZAlFpo4A+1uBVCxqpKz9D26uTF4srRXaGTTsikQmaotCtNdbhzyUH7ft6p9ktz9s6UNQ==",
+          "version": "17.0.20",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.20.tgz",
+          "integrity": "sha512-eknWrTHofQuPk2iuqDm1waA7V6xPlbgBoaaXEgYkClhLOnB0TtbW+srJaOToAgawPxPlHQzwypFA2bhZaUGP5A==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -43238,9 +43205,9 @@
           }
         },
         "@types/yargs": {
-          "version": "17.0.19",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.19.tgz",
-          "integrity": "sha512-cAx3qamwaYX9R0fzOIZAlFpo4A+1uBVCxqpKz9D26uTF4srRXaGTTsikQmaotCtNdbhzyUH7ft6p9ktz9s6UNQ==",
+          "version": "17.0.20",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.20.tgz",
+          "integrity": "sha512-eknWrTHofQuPk2iuqDm1waA7V6xPlbgBoaaXEgYkClhLOnB0TtbW+srJaOToAgawPxPlHQzwypFA2bhZaUGP5A==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -43478,9 +43445,9 @@
           }
         },
         "@types/yargs": {
-          "version": "17.0.19",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.19.tgz",
-          "integrity": "sha512-cAx3qamwaYX9R0fzOIZAlFpo4A+1uBVCxqpKz9D26uTF4srRXaGTTsikQmaotCtNdbhzyUH7ft6p9ktz9s6UNQ==",
+          "version": "17.0.20",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.20.tgz",
+          "integrity": "sha512-eknWrTHofQuPk2iuqDm1waA7V6xPlbgBoaaXEgYkClhLOnB0TtbW+srJaOToAgawPxPlHQzwypFA2bhZaUGP5A==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -43569,9 +43536,9 @@
           }
         },
         "@types/yargs": {
-          "version": "17.0.19",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.19.tgz",
-          "integrity": "sha512-cAx3qamwaYX9R0fzOIZAlFpo4A+1uBVCxqpKz9D26uTF4srRXaGTTsikQmaotCtNdbhzyUH7ft6p9ktz9s6UNQ==",
+          "version": "17.0.20",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.20.tgz",
+          "integrity": "sha512-eknWrTHofQuPk2iuqDm1waA7V6xPlbgBoaaXEgYkClhLOnB0TtbW+srJaOToAgawPxPlHQzwypFA2bhZaUGP5A==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -43693,9 +43660,9 @@
           }
         },
         "@types/yargs": {
-          "version": "17.0.19",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.19.tgz",
-          "integrity": "sha512-cAx3qamwaYX9R0fzOIZAlFpo4A+1uBVCxqpKz9D26uTF4srRXaGTTsikQmaotCtNdbhzyUH7ft6p9ktz9s6UNQ==",
+          "version": "17.0.20",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.20.tgz",
+          "integrity": "sha512-eknWrTHofQuPk2iuqDm1waA7V6xPlbgBoaaXEgYkClhLOnB0TtbW+srJaOToAgawPxPlHQzwypFA2bhZaUGP5A==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -43889,9 +43856,9 @@
           }
         },
         "@types/yargs": {
-          "version": "17.0.19",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.19.tgz",
-          "integrity": "sha512-cAx3qamwaYX9R0fzOIZAlFpo4A+1uBVCxqpKz9D26uTF4srRXaGTTsikQmaotCtNdbhzyUH7ft6p9ktz9s6UNQ==",
+          "version": "17.0.20",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.20.tgz",
+          "integrity": "sha512-eknWrTHofQuPk2iuqDm1waA7V6xPlbgBoaaXEgYkClhLOnB0TtbW+srJaOToAgawPxPlHQzwypFA2bhZaUGP5A==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -44118,9 +44085,9 @@
           }
         },
         "@types/yargs": {
-          "version": "17.0.19",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.19.tgz",
-          "integrity": "sha512-cAx3qamwaYX9R0fzOIZAlFpo4A+1uBVCxqpKz9D26uTF4srRXaGTTsikQmaotCtNdbhzyUH7ft6p9ktz9s6UNQ==",
+          "version": "17.0.20",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.20.tgz",
+          "integrity": "sha512-eknWrTHofQuPk2iuqDm1waA7V6xPlbgBoaaXEgYkClhLOnB0TtbW+srJaOToAgawPxPlHQzwypFA2bhZaUGP5A==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -44337,9 +44304,9 @@
           }
         },
         "@types/yargs": {
-          "version": "17.0.19",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.19.tgz",
-          "integrity": "sha512-cAx3qamwaYX9R0fzOIZAlFpo4A+1uBVCxqpKz9D26uTF4srRXaGTTsikQmaotCtNdbhzyUH7ft6p9ktz9s6UNQ==",
+          "version": "17.0.20",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.20.tgz",
+          "integrity": "sha512-eknWrTHofQuPk2iuqDm1waA7V6xPlbgBoaaXEgYkClhLOnB0TtbW+srJaOToAgawPxPlHQzwypFA2bhZaUGP5A==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -44576,9 +44543,9 @@
           }
         },
         "@types/yargs": {
-          "version": "17.0.19",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.19.tgz",
-          "integrity": "sha512-cAx3qamwaYX9R0fzOIZAlFpo4A+1uBVCxqpKz9D26uTF4srRXaGTTsikQmaotCtNdbhzyUH7ft6p9ktz9s6UNQ==",
+          "version": "17.0.20",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.20.tgz",
+          "integrity": "sha512-eknWrTHofQuPk2iuqDm1waA7V6xPlbgBoaaXEgYkClhLOnB0TtbW+srJaOToAgawPxPlHQzwypFA2bhZaUGP5A==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -44666,9 +44633,9 @@
           }
         },
         "@types/yargs": {
-          "version": "17.0.19",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.19.tgz",
-          "integrity": "sha512-cAx3qamwaYX9R0fzOIZAlFpo4A+1uBVCxqpKz9D26uTF4srRXaGTTsikQmaotCtNdbhzyUH7ft6p9ktz9s6UNQ==",
+          "version": "17.0.20",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.20.tgz",
+          "integrity": "sha512-eknWrTHofQuPk2iuqDm1waA7V6xPlbgBoaaXEgYkClhLOnB0TtbW+srJaOToAgawPxPlHQzwypFA2bhZaUGP5A==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -44778,9 +44745,9 @@
           }
         },
         "@types/yargs": {
-          "version": "17.0.19",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.19.tgz",
-          "integrity": "sha512-cAx3qamwaYX9R0fzOIZAlFpo4A+1uBVCxqpKz9D26uTF4srRXaGTTsikQmaotCtNdbhzyUH7ft6p9ktz9s6UNQ==",
+          "version": "17.0.20",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.20.tgz",
+          "integrity": "sha512-eknWrTHofQuPk2iuqDm1waA7V6xPlbgBoaaXEgYkClhLOnB0TtbW+srJaOToAgawPxPlHQzwypFA2bhZaUGP5A==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -50006,9 +49973,9 @@
       }
     },
     "resolve.exports": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-1.1.0.tgz",
-      "integrity": "sha512-J1l+Zxxp4XK3LUDZ9m60LRJF/mAe4z6a4xyabPHk7pvK5t35dACV32iIjJDFeWZFfZlO29w6SZ67knR0tHzJtQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-1.1.1.tgz",
+      "integrity": "sha512-/NtpHNDN7jWhAaQ9BvBUYZ6YTXsRBgfqWFWP7BZBaoMJO/I3G5OFzvTuWNlZC3aPjins1F+TNrLKsGbH4rfsRQ==",
       "dev": true
     },
     "ret": {
@@ -50094,7 +50061,8 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -52597,19 +52565,6 @@
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
           "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
-      }
-    },
-    "util": {
-      "version": "0.12.4",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
-      "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
-      "requires": {
-        "inherits": "^2.0.3",
-        "is-arguments": "^1.0.4",
-        "is-generator-function": "^1.0.7",
-        "is-typed-array": "^1.1.3",
-        "safe-buffer": "^5.1.2",
-        "which-typed-array": "^1.1.2"
       }
     },
     "util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "redux-thunk": "2.3.0",
     "regenerator-runtime": "^0.13.7",
     "sass": "^1.49.0",
-    "util": "^0.12.3",
     "whatwg-fetch": "^2.0.4"
   },
   "devDependencies": {


### PR DESCRIPTION
This is an attempt to update and merge an old pr: https://github.com/openedx/frontend-app-gradebook/pull/201

The only remaining change is to remove the `util` package as a dependency. So, here it is.