### PR TITLE
fix: Fix rows counter in the Edit Grade modal window

### DIFF
--- a/src/components/GradesView/EditModal/OverrideTable/__snapshots__/index.test.jsx.snap
+++ b/src/components/GradesView/EditModal/OverrideTable/__snapshots__/index.test.jsx.snap
@@ -20,6 +20,6 @@ exports[`OverrideTable component render snapshot 1`] = `
       },
     ]
   }
-  itemCount={2}
+  itemCount={3}
 />
 `;

--- a/src/components/GradesView/EditModal/OverrideTable/index.jsx
+++ b/src/components/GradesView/EditModal/OverrideTable/index.jsx
@@ -20,18 +20,20 @@ export const OverrideTable = () => {
 
   if (hide) { return null; }
 
+  const tableData = [
+    ...data,
+    {
+      adjustedGrade: <AdjustedGradeInput />,
+      date: formatDateForDisplay(new Date()),
+      reason: <ReasonInput />,
+    },
+  ];
+
   return (
     <DataTable
       columns={columns}
-      data={[
-        ...data,
-        {
-          adjustedGrade: <AdjustedGradeInput />,
-          date: formatDateForDisplay(new Date()),
-          reason: <ReasonInput />,
-        },
-      ]}
-      itemCount={data.length}
+      data={tableData}
+      itemCount={tableData.length}
     />
   );
 };


### PR DESCRIPTION
**TL;DR -** The problem was in the rows counter in the Edit Grades modal window. First digit - number of lines excluding the last line with the form. Second digit - grades data. And our proposal is to include last row with form to common counting

<img width="1904" alt="Снимок экрана 2023-02-10 в 15 25 06" src="https://user-images.githubusercontent.com/19806032/218103195-661c7642-72cb-49bd-be9a-bfe7f8fd0eb3.png">

**What changed?**

<img width="1904" alt="Снимок экрана 2023-02-10 в 15 42 01" src="https://user-images.githubusercontent.com/19806032/218106655-0a52059c-4041-4c5d-935a-9c89b8183bc2.png">

FYI: @openedx/content-aurora
