### PR TITLE
fix: file input handler

### DIFF
--- a/src/components/GradesView/ImportGradesButton/hooks.js
+++ b/src/components/GradesView/ImportGradesButton/hooks.js
@@ -6,11 +6,10 @@ export const useImportButtonData = () => {
   const submitImportGradesButtonData = thunkActions.grades.useSubmitImportGradesButtonData();
 
   const fileInputRef = useRef();
-  const hasFile = fileInputRef.current && fileInputRef.current.files[0];
 
-  const handleClickImportGrades = () => hasFile && fileInputRef.current.click();
+  const handleClickImportGrades = () => fileInputRef.current?.click();
   const handleFileInputChange = () => {
-    if (hasFile) {
+    if (fileInputRef.current?.files[0]) {
       const clearInput = () => {
         fileInputRef.current.value = null;
       };


### PR DESCRIPTION
**TL;DR -** `hasFile` run only once, it will always be `null`

JIRA: https://2u-internal.atlassian.net/browse/CR-5738

**Developer Checklist**
- [ ] Test suites passing
- [ ] Documentation and test plan updated, if applicable
- [ ] Received code-owner approving review
- [ ] Bumped version number [package.json](../package.json)

**Testing Instructions**

[ How should a reviewer test this PR? ]

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review
- [ ] I've tested the new functionality


FYI: @openedx/content-aurora
