### PR TITLE
fix: replace Field.Email reference for Field.Text

### DIFF
--- a/src/components/GradesView/GradebookTable/GradeButton.jsx
+++ b/src/components/GradesView/GradebookTable/GradeButton.jsx
@@ -11,7 +11,7 @@ export const useGradeButtonData = ({ entry, subsection }) => {
   const areGradesFrozen = selectors.assignmentTypes.useAreGradesFrozen();
   const { gradeFormat } = selectors.grades.useGradeData();
   const setModalState = thunkActions.app.useSetModalStateFromTable();
-  const label = transforms.grades.subsectionGrade({ gradeFormat, subsection });
+  const label = transforms.grades.subsectionGrade({ gradeFormat, subsection })();
 
   const onClick = () => {
     setModalState({

--- a/src/components/GradesView/GradebookTable/GradeButton.test.jsx
+++ b/src/components/GradesView/GradebookTable/GradeButton.test.jsx
@@ -41,7 +41,7 @@ const props = {
 };
 const gradeFormat = 'percent';
 const setModalState = jest.fn();
-const subsectionGrade = 'test-subsection-grade';
+const subsectionGrade = () => 'test-subsection-grade';
 selectors.assignmentTypes.useAreGradesFrozen.mockReturnValue(false);
 selectors.grades.useGradeData.mockReturnValue({ gradeFormat });
 thunkActions.app.useSetModalStateFromTable.mockReturnValue(setModalState);
@@ -73,7 +73,7 @@ describe('GradeButton', () => {
         expect(out.areGradesFrozen).toEqual(false);
       });
       test('label passed from subsection grade redux hook', () => {
-        expect(out.label).toEqual(subsectionGrade);
+        expect(out.label).toEqual(subsectionGrade());
       });
       test('onClick sets modal state with user entry and subsection', () => {
         out.onClick();

--- a/src/components/GradesView/GradebookTable/hooks.jsx
+++ b/src/components/GradesView/GradebookTable/hooks.jsx
@@ -39,7 +39,7 @@ export const useGradebookTableData = () => {
     [Headings.username]: (
       <Fields.Username username={entry.username} userKey={entry.external_user_key} />
     ),
-    [Headings.email]: (<Fields.Email email={entry.email} />),
+    [Headings.email]: (<Fields.Text value={entry.email} />),
     [Headings.totalGrade]: `${roundGrade(entry.percent * 100)}${getLocalizedPercentSign()}`,
     ...entry.section_breakdown.reduce((acc, subsection) => ({
       ...acc,

--- a/src/components/GradesView/GradebookTable/hooks.test.jsx
+++ b/src/components/GradesView/GradebookTable/hooks.test.jsx
@@ -22,7 +22,7 @@ jest.mock('i18n/utils', () => ({
 jest.mock('./GradeButton', () => 'GradeButton');
 jest.mock('./Fields', () => jest.requireActual('testUtils').mockNestedComponents({
   Username: 'Fields.Username',
-  Email: 'Fields.Email',
+  Text: 'Fields.Text',
 }));
 jest.mock('./LabelReplacements', () => jest.requireActual('testUtils').mockNestedComponents({
   TotalGradeLabelReplacement: 'LabelReplacements.TotalGradeLabelReplacement',
@@ -158,7 +158,7 @@ describe('useGradebookTableData', () => {
       test('email field', () => {
         allGrades.forEach((entry, index) => {
           expect(out.data[index][Headings.email]).toMatchObject(
-            <Fields.Email email={entry.email} />,
+            <Fields.Text value={entry.email} />,
           );
         });
       });


### PR DESCRIPTION
**Description**
The master branch doesn't have the references to new Field.Text updated, there is a screenshot of the error 

![image](https://github.com/openedx/frontend-app-gradebook/assets/66016493/4a8e0014-9c24-4183-b67f-bc2444472b34)

As well `useGradeButtonData` doesn't return  a string in the label field is returning a function, so the numbers weren't render 
![image](https://github.com/openedx/frontend-app-gradebook/assets/66016493/60ef3ca5-daad-4a9e-bba2-b03b156f38e4)

This PR tries to solve that rendering situation. 

**What changed?**

- Update the reference for Field.Email to Field.Text
- Update the test.

**Developer Checklist**
- [ ] Test suites passing
- [ ] Documentation and test plan updated, if applicable
- [ ] Received code-owner approving review
- [ ] Bumped version number [package.json](../package.json)


**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review
- [ ] I've tested the new functionality


FYI: @openedx/content-aurora
