### PR TITLE
fix: add limited_staff to allowedRoles [BB-7834]

### DIFF
--- a/src/data/thunkActions/roles.js
+++ b/src/data/thunkActions/roles.js
@@ -10,7 +10,7 @@ import { fetchGrades } from './grades';
 import { fetchTracks } from './tracks';
 import { fetchAssignmentTypes } from './assignmentTypes';
 
-export const allowedRoles = ['staff', 'instructor', 'support'];
+export const allowedRoles = ['staff', 'limited_staff', 'instructor', 'support'];
 
 export const fetchRoles = () => (
   (dispatch, getState) => {


### PR DESCRIPTION
## Description

Users with the Course Limited Staff role, that has been added [here](https://github.com/openedx/edx-platform/pull/32570), don't have access to the gradebook. In this PR we add [this role's slug](https://github.com/openedx/edx-platform/blob/20efcdc94c85a5e96bf12c75b4beaece4cca452d/common/djangoapps/student/roles.py#L285) to `allowedRoles`.

## Testing instructions

The fix is pretty trivial, so just make sure that the slug in `allowedRoles` is equal to `CourseLimitedStaffRole.ROLE` value.