### PR TITLE
fix: fix sidebar scrolling and adaptation for mobile

### DIFF
--- a/src/components/GradebookHeader/__snapshots__/test.jsx.snap
+++ b/src/components/GradebookHeader/__snapshots__/test.jsx.snap
@@ -29,7 +29,9 @@ exports[`GradebookHeader component snapshots default values (grades frozen, cann
   <div
     className="subtitle-row d-flex justify-content-between align-items-center"
   >
-    <h2>
+    <h2
+      className="text-break"
+    >
       fakeID
     </h2>
   </div>
@@ -75,7 +77,9 @@ exports[`GradebookHeader component snapshots grades frozen, can view. grades fro
   <div
     className="subtitle-row d-flex justify-content-between align-items-center"
   >
-    <h2>
+    <h2
+      className="text-break"
+    >
       fakeID
     </h2>
   </div>
@@ -121,7 +125,9 @@ exports[`GradebookHeader component snapshots grades frozen, cannot view unauthor
   <div
     className="subtitle-row d-flex justify-content-between align-items-center"
   >
-    <h2>
+    <h2
+      className="text-break"
+    >
       fakeID
     </h2>
   </div>
@@ -177,7 +183,9 @@ exports[`GradebookHeader component snapshots show bulk management, active view i
   <div
     className="subtitle-row d-flex justify-content-between align-items-center"
   >
-    <h2>
+    <h2
+      className="text-break"
+    >
       fakeID
     </h2>
     <Button
@@ -233,7 +241,9 @@ exports[`GradebookHeader component snapshots show bulk management, active view i
   <div
     className="subtitle-row d-flex justify-content-between align-items-center"
   >
-    <h2>
+    <h2
+      className="text-break"
+    >
       fakeID
     </h2>
     <Button

--- a/src/components/GradebookHeader/index.jsx
+++ b/src/components/GradebookHeader/index.jsx
@@ -47,7 +47,7 @@ export class GradebookHeader extends React.Component {
           <FormattedMessage {...messages.gradebook} />
         </h1>
         <div className="subtitle-row d-flex justify-content-between align-items-center">
-          <h2>{this.props.courseId}</h2>
+          <h2 className="text-break">{this.props.courseId}</h2>
           { this.props.showBulkManagement && (
             <Button
               variant="tertiary"

--- a/src/components/GradesView/FilterMenuToggle.jsx
+++ b/src/components/GradesView/FilterMenuToggle.jsx
@@ -19,7 +19,7 @@ export const FilterMenuToggle = ({ toggleFilterDrawer }) => (
     className="btn-primary align-self-start"
     onClick={toggleFilterDrawer}
   >
-    <Icon className="fa fa-filter" /> <FormattedMessage {...messages.editFilters} />
+    <Icon className="fa fa-filter mr-1" /> <FormattedMessage {...messages.editFilters} />
   </Button>
 );
 

--- a/src/components/GradesView/GradesView.scss
+++ b/src/components/GradesView/GradesView.scss
@@ -46,6 +46,7 @@
 }
 .grade-history-header{
     float: left;
+    min-width: 170px;
 }
 
 .grade-history-assignment{
@@ -65,7 +66,7 @@
 .gradebook-container {
     width: 100%;
     overflow-x: auto;
-    height: 600px;
+    max-height: 600px;
     overflow-y: auto;
     position: relative;
 }
@@ -120,5 +121,36 @@ select#ScoreView.form-control {
     &:before {
         border-width: 0.4rem 0.4rem 0.4rem 0;
         border-right-color: $black;
+    }
+}
+
+#edit-filters-btn {
+    @include media-breakpoint-down(xs) {
+        width: 100%;
+        margin-bottom: 1rem;
+    }
+}
+
+.search-container {
+    @include media-breakpoint-down(xs) {
+        width: 100%;
+    }
+}
+
+.pgn__modal-body-content .pgn__data-table-layout-wrapper {
+    @include media-breakpoint-down(sm) {
+        clear: both;
+        padding: 1rem 0;
+    }
+}
+
+.page-gradebook {
+    position: relative;
+
+    .sidebar-container {
+        position: relative;
+    }
+    aside.sidebar {
+        overflow: auto;
     }
 }

--- a/src/components/GradesView/SearchControls.jsx
+++ b/src/components/GradesView/SearchControls.jsx
@@ -40,7 +40,7 @@ export class SearchControls extends React.Component {
 
   render() {
     return (
-      <div>
+      <div className="search-container">
         <SearchField
           onSubmit={this.onSubmit}
           inputLabel={<FormattedMessage {...messages.label} />}

--- a/src/components/GradesView/__snapshots__/FilterMenuToggle.test.jsx.snap
+++ b/src/components/GradesView/__snapshots__/FilterMenuToggle.test.jsx.snap
@@ -7,7 +7,7 @@ exports[`FilterMenuToggle component snapshots basic snapshot 1`] = `
   onClick={[MockFunction this.props.toggleFilterDrawer]}
 >
   <Icon
-    className="fa fa-filter"
+    className="fa fa-filter mr-1"
   />
    
   <FormattedMessage

--- a/src/components/GradesView/__snapshots__/SearchControls.test.jsx.snap
+++ b/src/components/GradesView/__snapshots__/SearchControls.test.jsx.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SearchControls Component Snapshots basic snapshot 1`] = `
-<div>
+<div
+  className="search-container"
+>
   <SearchField
     inputLabel={
       <FormattedMessage

--- a/src/components/GradesView/__snapshots__/test.jsx.snap
+++ b/src/components/GradesView/__snapshots__/test.jsx.snap
@@ -14,7 +14,7 @@ exports[`GradesView Component snapshots basic snapshot 1`] = `
     />
   </h3>
   <div
-    className="d-flex justify-content-between"
+    className="d-flex justify-content-between flex-wrap"
   >
     <FilterMenuToggle />
     <SearchControls />

--- a/src/components/GradesView/index.jsx
+++ b/src/components/GradesView/index.jsx
@@ -50,7 +50,7 @@ export class GradesView extends React.Component {
           <FormattedMessage {...messages.filterStepHeading} />
         </h3>
 
-        <div className="d-flex justify-content-between">
+        <div className="d-flex justify-content-between flex-wrap">
           <FilterMenuToggle />
           <SearchControls />
         </div>


### PR DESCRIPTION
**TL;DR -**

This pull request contains minor fixes related to the responsiveness of the blocks for mobile phones. All the before and after screenshots are below.

**Related Pull Requests**
PR to the master branch: https://github.com/openedx/frontend-app-gradebook/pull/363
PR to the open-release/quince.master branch: https://github.com/openedx/frontend-app-gradebook/pull/370

**What changed?**
- fixed text overload in the title when the course ID is too long

|  Before |  After |
|---|---|
|  <img width="427" alt="image" src="https://github.com/openedx/frontend-app-gradebook/assets/17108583/71ccc26b-1098-47fa-92fb-162816071dc8"> |  <img width="374" alt="image" src="https://github.com/openedx/frontend-app-gradebook/assets/17108583/8c5c5803-0d7d-4821-b0c8-afc127c9c1d0"> |

- fixed appearance and scrolling of the sidebar

|  Before |  After |
|---|---|
|  <img width="707" alt="image" src="https://github.com/openedx/frontend-app-gradebook/assets/17108583/0ef26199-a6b7-4f61-8df6-f52426baeaff"> |  <img width="867" alt="image" src="https://github.com/openedx/frontend-app-gradebook/assets/17108583/3bb39b4e-130b-498b-88ea-6d1b50960d7b"> |
|   <img width="333" alt="image" src="https://github.com/openedx/frontend-app-gradebook/assets/17108583/4a429288-fefd-44e7-a0fb-75d4e51cfeee">  |   <img width="332" alt="image" src="https://github.com/openedx/frontend-app-gradebook/assets/17108583/c1e10328-4079-4b17-921c-3c70cdaad27c"> |

- Fixed adaptation of the search and filter buttons on mobile phones.

|  Before |  After |
|---|---|
|  <img width="430" alt="image" src="https://github.com/openedx/frontend-app-gradebook/assets/17108583/dd483047-c357-44f3-a5bc-bf4a5785436b"> |  <img width="430" alt="image" src="https://github.com/openedx/frontend-app-gradebook/assets/17108583/35711f9d-6a5b-4d1a-b950-bee099ab6b1e"> |

- removed excess empty space under the main table of contents

|  Before |  After |
|---|---|
|  <img width="1727" alt="image" src="https://github.com/openedx/frontend-app-gradebook/assets/17108583/d9c24321-1a3a-4493-9e80-0dde76c18a1f"> |  <img width="1726" alt="image" src="https://github.com/openedx/frontend-app-gradebook/assets/17108583/adec6b65-5da0-4300-9887-8726199b00a7"> |

- fix adaptation modal content to mobile view

|  Before |  After |
|---|---|
|  <img width="479" alt="image" src="https://github.com/openedx/frontend-app-gradebook/assets/17108583/1b5c91a6-7faa-42d5-9803-007077b24527">  |  <img width="483" alt="image" src="https://github.com/openedx/frontend-app-gradebook/assets/17108583/bc573588-9c9a-4e60-811d-725eb9ab53d0"> |

**Developer Checklist**
- [ ] Test suites passing
- [ ] Documentation and test plan updated, if applicable
- [ ] Received code-owner approving review
- [ ] Bumped version number [package.json](../package.json)

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review
- [ ] I've tested the new functionality


FYI: @openedx/content-aurora
