### PR TITLE
feat: adjusted grade field validation

### DIFF
--- a/src/components/GradesView/EditModal/OverrideTable/AdjustedGradeInput/hooks.js
+++ b/src/components/GradesView/EditModal/OverrideTable/AdjustedGradeInput/hooks.js
@@ -8,13 +8,25 @@ const useAdjustedGradeInputData = () => {
   const hintText = possibleGrade && ` ${getLocalizedSlash()} ${possibleGrade}`;
 
   const onChange = ({ target }) => {
-    setModalState({ adjustedGradeValue: target.value });
+    let adjustedGradeValue;
+    switch (true) {
+      case target.value < 0:
+        adjustedGradeValue = 0;
+        break;
+      case possibleGrade && target.value > possibleGrade:
+        adjustedGradeValue = possibleGrade;
+        break;
+      default:
+        adjustedGradeValue = target.value;
+    }
+    setModalState({ adjustedGradeValue });
   };
 
   return {
     value,
     onChange,
     hintText,
+    possibleGrade,
   };
 };
 

--- a/src/components/GradesView/EditModal/OverrideTable/AdjustedGradeInput/index.jsx
+++ b/src/components/GradesView/EditModal/OverrideTable/AdjustedGradeInput/index.jsx
@@ -14,12 +14,15 @@ export const AdjustedGradeInput = () => {
     value,
     onChange,
     hintText,
+    possibleGrade,
   } = useAdjustedGradeInputData();
   return (
     <span>
       <Form.Control
-        type="text"
+        type="number"
         name="adjustedGradeValue"
+        min="0"
+        max={possibleGrade || ''}
         value={value}
         onChange={onChange}
       />


### PR DESCRIPTION
**TL;DR -** added simple validation for the "Adjusted grade" field in the "Edit Grades" popup:

- enter only a numeric value
- setting the minimum value
- checking the correctness of the entered value to possibleGrade

Related: [master](https://github.com/openedx/frontend-app-gradebook/pull/364)

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review
- [ ] I've tested the new functionality


FYI: @openedx/content-aurora
