### PR TITLE
fix: fix sidebar scrolling and adaptation for mobile

### DIFF
--- a/src/components/GradebookHeader/__snapshots__/index.test.jsx.snap
+++ b/src/components/GradebookHeader/__snapshots__/index.test.jsx.snap
@@ -21,7 +21,9 @@ exports[`GradebookHeader component render default view shapshot 1`] = `
   <div
     className="subtitle-row d-flex justify-content-between align-items-center"
   >
-    <h2>
+    <h2
+      className="text-break"
+    >
       test-course-id
     </h2>
   </div>
@@ -49,7 +51,9 @@ exports[`GradebookHeader component render frozen grades snapshot: show frozen wa
   <div
     className="subtitle-row d-flex justify-content-between align-items-center"
   >
-    <h2>
+    <h2
+      className="text-break"
+    >
       test-course-id
     </h2>
   </div>
@@ -83,7 +87,9 @@ exports[`GradebookHeader component render show bulk management snapshot: show to
   <div
     className="subtitle-row d-flex justify-content-between align-items-center"
   >
-    <h2>
+    <h2
+      className="text-break"
+    >
       test-course-id
     </h2>
     <Button
@@ -117,7 +123,9 @@ exports[`GradebookHeader component render user cannot view gradebook snapshot: s
   <div
     className="subtitle-row d-flex justify-content-between align-items-center"
   >
-    <h2>
+    <h2
+      className="text-break"
+    >
       test-course-id
     </h2>
   </div>

--- a/src/components/GradebookHeader/index.jsx
+++ b/src/components/GradebookHeader/index.jsx
@@ -26,7 +26,7 @@ export const GradebookHeader = () => {
       </a>
       <h1>{formatMessage(messages.gradebook)}</h1>
       <div className="subtitle-row d-flex justify-content-between align-items-center">
-        <h2>{courseId}</h2>
+        <h2 className="text-break">{courseId}</h2>
         {showBulkManagement && (
           <Button variant="tertiary" onClick={handleToggleViewClick}>
             {formatMessage(toggleViewMessage)}

--- a/src/components/GradesView/FilterMenuToggle/__snapshots__/index.test.jsx.snap
+++ b/src/components/GradesView/FilterMenuToggle/__snapshots__/index.test.jsx.snap
@@ -7,6 +7,7 @@ exports[`FilterMenuToggle component render snapshot 1`] = `
   onClick={[MockFunction hooks.toggleFilterMenu]}
 >
   <Icon
+    className="mr-1"
     src="FilterAlt"
   />
    

--- a/src/components/GradesView/FilterMenuToggle/index.jsx
+++ b/src/components/GradesView/FilterMenuToggle/index.jsx
@@ -21,7 +21,7 @@ export const FilterMenuToggle = () => {
       className="btn-primary align-self-start"
       onClick={toggleFilterMenu}
     >
-      <Icon src={FilterAlt} /> {formatMessage(messages.editFilters)}
+      <Icon src={FilterAlt} className="mr-1" /> {formatMessage(messages.editFilters)}
     </Button>
   );
 };

--- a/src/components/GradesView/GradesView.scss
+++ b/src/components/GradesView/GradesView.scss
@@ -46,6 +46,7 @@
 }
 .grade-history-header{
     float: left;
+    min-width: 170px;
 }
 
 .grade-history-assignment{
@@ -65,7 +66,7 @@
 .gradebook-container {
     width: 100%;
     overflow-x: auto;
-    height: 600px;
+    max-height: 600px;
     overflow-y: auto;
     position: relative;
 }
@@ -120,5 +121,36 @@ select#ScoreView.form-control {
     &:before {
         border-width: 0.4rem 0.4rem 0.4rem 0;
         border-right-color: $black;
+    }
+}
+
+#edit-filters-btn {
+    @include media-breakpoint-down(xs) {
+        width: 100%;
+        margin-bottom: 1rem;
+    }
+}
+
+.search-container {
+    @include media-breakpoint-down(xs) {
+        width: 100%;
+    }
+}
+
+.pgn__modal-body-content .pgn__data-table-layout-wrapper {
+    @include media-breakpoint-down(sm) {
+        clear: both;
+        padding: 1rem 0;
+    }
+}
+
+.page-gradebook {
+    position: relative;
+
+    .sidebar-container {
+        position: relative;
+    }
+    aside.sidebar {
+        overflow: auto;
     }
 }

--- a/src/components/GradesView/SearchControls/__snapshots__/index.test.jsx.snap
+++ b/src/components/GradesView/SearchControls/__snapshots__/index.test.jsx.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SearchControls component render snapshot 1`] = `
-<div>
+<div
+  className="search-container"
+>
   <SearchField
     inputLabel="test-input-label"
     onBlur={[MockFunction hooks.onBlur]}

--- a/src/components/GradesView/SearchControls/index.jsx
+++ b/src/components/GradesView/SearchControls/index.jsx
@@ -18,7 +18,7 @@ export const SearchControls = () => {
   } = useSearchControlsData();
 
   return (
-    <div>
+    <div className="search-container">
       <SearchField
         onSubmit={onSubmit}
         inputLabel={inputLabel}

--- a/src/components/GradesView/__snapshots__/index.test.jsx.snap
+++ b/src/components/GradesView/__snapshots__/index.test.jsx.snap
@@ -10,7 +10,7 @@ exports[`GradesView component render snapshot 1`] = `
     filter-step-heading
   </h3>
   <div
-    className="d-flex justify-content-between"
+    className="d-flex justify-content-between flex-wrap"
   >
     <FilterMenuToggle />
     <SearchControls />

--- a/src/components/GradesView/index.jsx
+++ b/src/components/GradesView/index.jsx
@@ -34,7 +34,7 @@ export const GradesView = ({ updateQueryParams }) => {
         {stepHeadings.filter}
       </h3>
 
-      <div className="d-flex justify-content-between">
+      <div className="d-flex justify-content-between flex-wrap">
         <FilterMenuToggle />
         <SearchControls />
       </div>


### PR DESCRIPTION
**TL;DR -**

This pull request contains minor fixes related to the responsiveness of the blocks for mobile phones. All the before and after screenshots are below.

**Related Pull Requests**
PR to the open-release/palm.master branch: https://github.com/openedx/frontend-app-gradebook/pull/362
PR to the master branch: https://github.com/openedx/frontend-app-gradebook/pull/363

**What changed?**
- fixed text overload in the title when the course ID is too long

|  Before |  After |
|---|---|
|  <img width="427" alt="image" src="https://github.com/openedx/frontend-app-gradebook/assets/17108583/71ccc26b-1098-47fa-92fb-162816071dc8"> |  <img width="374" alt="image" src="https://github.com/openedx/frontend-app-gradebook/assets/17108583/8c5c5803-0d7d-4821-b0c8-afc127c9c1d0"> |

- fixed appearance and scrolling of the sidebar

|  Before |  After |
|---|---|
|  <img width="707" alt="image" src="https://github.com/openedx/frontend-app-gradebook/assets/17108583/0ef26199-a6b7-4f61-8df6-f52426baeaff"> |  <img width="867" alt="image" src="https://github.com/openedx/frontend-app-gradebook/assets/17108583/3bb39b4e-130b-498b-88ea-6d1b50960d7b"> |
|   <img width="333" alt="image" src="https://github.com/openedx/frontend-app-gradebook/assets/17108583/4a429288-fefd-44e7-a0fb-75d4e51cfeee">  |   <img width="332" alt="image" src="https://github.com/openedx/frontend-app-gradebook/assets/17108583/c1e10328-4079-4b17-921c-3c70cdaad27c"> |

- Fixed adaptation of the search and filter buttons on mobile phones.

|  Before |  After |
|---|---|
|  <img width="430" alt="image" src="https://github.com/openedx/frontend-app-gradebook/assets/17108583/dd483047-c357-44f3-a5bc-bf4a5785436b"> |  <img width="430" alt="image" src="https://github.com/openedx/frontend-app-gradebook/assets/17108583/35711f9d-6a5b-4d1a-b950-bee099ab6b1e"> |

- removed excess empty space under the main table of contents

|  Before |  After |
|---|---|
|  <img width="1727" alt="image" src="https://github.com/openedx/frontend-app-gradebook/assets/17108583/d9c24321-1a3a-4493-9e80-0dde76c18a1f"> |  <img width="1726" alt="image" src="https://github.com/openedx/frontend-app-gradebook/assets/17108583/adec6b65-5da0-4300-9887-8726199b00a7"> |

- fix adaptation modal content to mobile view

|  Before |  After |
|---|---|
|  <img width="479" alt="image" src="https://github.com/openedx/frontend-app-gradebook/assets/17108583/1b5c91a6-7faa-42d5-9803-007077b24527">  |  <img width="483" alt="image" src="https://github.com/openedx/frontend-app-gradebook/assets/17108583/bc573588-9c9a-4e60-811d-725eb9ab53d0"> |

**Developer Checklist**
- [ ] Test suites passing
- [ ] Documentation and test plan updated, if applicable
- [ ] Received code-owner approving review
- [ ] Bumped version number [package.json](../package.json)

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review
- [ ] I've tested the new functionality


FYI: @openedx/content-aurora
