### PR TITLE
fix: file input handler

### DIFF
--- a/src/components/GradesView/ImportGradesButton/hooks.js
+++ b/src/components/GradesView/ImportGradesButton/hooks.js
@@ -6,11 +6,10 @@ export const useImportButtonData = () => {
   const submitImportGradesButtonData = thunkActions.grades.useSubmitImportGradesButtonData();
 
   const fileInputRef = useRef();
-  const hasFile = fileInputRef.current && fileInputRef.current.files[0];
 
-  const handleClickImportGrades = () => hasFile && fileInputRef.current.click();
+  const handleClickImportGrades = () => fileInputRef.current?.click();
   const handleFileInputChange = () => {
-    if (hasFile) {
+    if (fileInputRef.current?.files[0]) {
       const clearInput = () => {
         fileInputRef.current.value = null;
       };


### PR DESCRIPTION
This is a [backport](https://github.com/openedx/frontend-app-gradebook/pull/323) from the master branch.

hasFile run only once, it will always be null

<img width="1669" alt="Знімок екрана 2023-10-27 о 17 33 46" src="https://github.com/openedx/frontend-app-gradebook/assets/98233552/611acc5d-85a1-432f-89b6-00fd44d42e94">
