### PR TITLE
fix: Route with PUBLIC_PATH

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,7 +6,6 @@ import { AppProvider } from '@edx/frontend-platform/react';
 import Footer from '@edx/frontend-component-footer';
 import Header from '@edx/frontend-component-header';
 
-import { routePath } from 'data/constants/app';
 import store from 'data/store';
 import GradebookPage from 'containers/GradebookPage';
 import './App.scss';
@@ -20,7 +19,7 @@ const App = () => (
       <main>
         <Routes>
           <Route
-            path={routePath}
+            path="/:courseId"
             element={<GradebookPage />}
           />
         </Routes>

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -7,7 +7,6 @@ import { AppProvider } from '@edx/frontend-platform/react';
 import Footer from '@edx/frontend-component-footer';
 import Header from '@edx/frontend-component-header';
 
-import { routePath } from 'data/constants/app';
 import store from 'data/store';
 import GradebookPage from 'containers/GradebookPage';
 
@@ -20,9 +19,6 @@ jest.mock('react-router-dom', () => ({
 }));
 jest.mock('@edx/frontend-platform/react', () => ({
   AppProvider: () => 'AppProvider',
-}));
-jest.mock('data/constants/app', () => ({
-  routePath: '/:courseId',
 }));
 jest.mock('@edx/frontend-component-footer', () => 'Footer');
 jest.mock('data/store', () => 'testStore');
@@ -66,7 +62,7 @@ describe('App router component', () => {
         expect(secondChild.find('main')).toEqual(shallow(
           <main>
             <Routes>
-              <Route path={routePath} element={<GradebookPage />} />
+              <Route path="/:courseId" element={<GradebookPage />} />
             </Routes>
           </main>,
         ));

--- a/src/data/constants/app.js
+++ b/src/data/constants/app.js
@@ -1,7 +1,4 @@
 import { StrictDict } from 'utils';
-import { getConfig } from '@edx/frontend-platform';
-
-export const routePath = `${getConfig().PUBLIC_PATH}:courseId`;
 
 export const views = StrictDict({
   grades: 'grades',


### PR DESCRIPTION
Prior to this change, the MFE would fail to render with any PUBLIC_PATH set.  Because that is now handled entirely by `frontend-platform`, we can avoid referring to PUBLIC_PATH at all.

**Developer Checklist**
- [x] Test suites passing
- [ ] Approving review

**Testing Instructions**

Using Tutor nightly in dev mode, without this patch the gradebook only shows a blank page.  With it, it actually renders.