### PR TITLE
feat: adjusted grade field validation

### DIFF
--- a/src/components/GradesView/EditModal/OverrideTable/AdjustedGradeInput/__snapshots__/index.test.jsx.snap
+++ b/src/components/GradesView/EditModal/OverrideTable/AdjustedGradeInput/__snapshots__/index.test.jsx.snap
@@ -3,9 +3,11 @@
 exports[`AdjustedGradeInput component render snapshot 1`] = `
 <span>
   <Form.Control
+    max=""
+    min="0"
     name="adjustedGradeValue"
     onChange={[MockFunction hook.onChange]}
-    type="text"
+    type="number"
     value="test-value"
   />
   some-hint-text

--- a/src/components/GradesView/EditModal/OverrideTable/AdjustedGradeInput/hooks.js
+++ b/src/components/GradesView/EditModal/OverrideTable/AdjustedGradeInput/hooks.js
@@ -8,13 +8,25 @@ const useAdjustedGradeInputData = () => {
   const hintText = possibleGrade && ` ${getLocalizedSlash()} ${possibleGrade}`;
 
   const onChange = ({ target }) => {
-    setModalState({ adjustedGradeValue: target.value });
+    let adjustedGradeValue;
+    switch (true) {
+      case target.value < 0:
+        adjustedGradeValue = 0;
+        break;
+      case possibleGrade && target.value > possibleGrade:
+        adjustedGradeValue = possibleGrade;
+        break;
+      default:
+        adjustedGradeValue = target.value;
+    }
+    setModalState({ adjustedGradeValue });
   };
 
   return {
     value,
     onChange,
     hintText,
+    possibleGrade,
   };
 };
 

--- a/src/components/GradesView/EditModal/OverrideTable/AdjustedGradeInput/hooks.test.jsx
+++ b/src/components/GradesView/EditModal/OverrideTable/AdjustedGradeInput/hooks.test.jsx
@@ -57,10 +57,25 @@ describe('useAdjustedGradeInputData hook', () => {
       });
     });
     describe('onChange', () => {
-      it('sets modal state with event target value', () => {
-        const testValue = 'test-value';
+      it('sets modal state with event target value when it is less than possibleGrade', () => {
+        const testValue = possibleGrade - 1;
         out.onChange({ target: { value: testValue } });
         expect(setModalState).toHaveBeenCalledWith({ adjustedGradeValue: testValue });
+      });
+      it('sets modal state with event target value when it is equal to possibleGrade', () => {
+        const testValue = possibleGrade;
+        out.onChange({ target: { value: testValue } });
+        expect(setModalState).toHaveBeenCalledWith({ adjustedGradeValue: testValue });
+      });
+      it('sets modal state to possibleGrade when event target value is greater than possibleGrade', () => {
+        const testValue = possibleGrade + 1;
+        out.onChange({ target: { value: testValue } });
+        expect(setModalState).toHaveBeenCalledWith({ adjustedGradeValue: possibleGrade });
+      });
+      it('sets modal state to 0 when event target value is less than 0', () => {
+        const testValue = -1;
+        out.onChange({ target: { value: testValue } });
+        expect(setModalState).toHaveBeenCalledWith({ adjustedGradeValue: 0 });
       });
     });
   });

--- a/src/components/GradesView/EditModal/OverrideTable/AdjustedGradeInput/index.jsx
+++ b/src/components/GradesView/EditModal/OverrideTable/AdjustedGradeInput/index.jsx
@@ -14,12 +14,15 @@ export const AdjustedGradeInput = () => {
     value,
     onChange,
     hintText,
+    possibleGrade,
   } = useAdjustedGradeInputData();
   return (
     <span>
       <Form.Control
-        type="text"
+        type="number"
         name="adjustedGradeValue"
+        min="0"
+        max={possibleGrade || ''}
         value={value}
         onChange={onChange}
       />


### PR DESCRIPTION
## Description
Added simple validation for the "Adjusted grade" field in the "Edit Grades" popup:

- allow only a numeric value
- define the minimum value (0)
- checking the correctness of the entered possibleGrade value

## Notes
This was already merged in [nutmeg](https://github.com/openedx/frontend-app-gradebook/pull/263) and [maple](https://github.com/openedx/frontend-app-gradebook/pull/264), but the PR to the master branch wasn't open at that time.

The same PR was opened for the master branch https://github.com/openedx/frontend-app-gradebook/pull/382

## Steps to reproduce
1. Go to Instructor -> Student admin -> View Gradebook
1. Click on any user
1. In the Adjusted grade field fill in symbols, letters, a large number

## Behaviour before the fix
Entering the large number has no errors and it's possible to save the incorrect value:
![image](https://github.com/openedx/frontend-app-gradebook/assets/47273130/ed337606-6a02-42d9-9bac-8a99409ba2e3)
![image](https://github.com/openedx/frontend-app-gradebook/assets/47273130/61d7cd7f-731d-4afb-b443-235efc61e0f2)

Entering text/special symbols results in 500 errors for the request:
![image](https://github.com/openedx/frontend-app-gradebook/assets/47273130/2d0883df-fee6-49bc-9028-9bc4a7bdb5e8)
![image](https://github.com/openedx/frontend-app-gradebook/assets/47273130/36793424-2845-44ac-aaee-37748836201d)
