### PR TITLE
fix: "An unexpected error occurred" after second opening any grade

### DIFF
--- a/src/components/GradesView/EditModal/OverrideTable/hooks.js
+++ b/src/components/GradesView/EditModal/OverrideTable/hooks.js
@@ -9,7 +9,7 @@ const useOverrideTableData = () => {
   const { formatMessage } = useIntl();
 
   const hide = selectors.grades.useHasOverrideErrors();
-  const gradeOverrides = selectors.grades.useGradeData().gradeOverrideHistoryResults;
+  const gradeOverrides = selectors.grades.useGradeData().gradeOverrideHistoryResults || [];
   const tableProps = {};
   if (!hide) {
     tableProps.columns = [


### PR DESCRIPTION
**This is a [backport](https://github.com/openedx/frontend-app-gradebook/pull/387) from the master branch.**

Hi! I found a bug.

1. Open Instructor -> Student admin -> View gradebook
2. Click on some grade
![screen_35](https://github.com/openedx/frontend-app-gradebook/assets/98233552/35b896c2-63f2-4511-b5c3-c33c54d4bbd4)

3. Set new grade or just click Cancel
4. Open same grade or another one
![screen_36](https://github.com/openedx/frontend-app-gradebook/assets/98233552/08937147-6505-4c1a-8c4b-87f55d46717f)

This happens because `doneViewingAssignment()` executes when the modal window closes. The redux state is being cleaned, namely, `gradeOverrideHistoryResults` is removed. 
Because of this, when we access this element again, we do not get the expected iterable object (list), but we get an `undefined`.
Previously, this was eliminated by the [default value](https://github.com/openedx/frontend-app-gradebook/blob/66bae174dd7f127844678d02b0784d42be0c2c43/src/components/GradesView/EditModal/OverrideTable/index.jsx#L53).
My suggestion is to also make the value default `[]` if `undefined`.

