### PR TITLE
feat: solve bug gradebook

### DIFF
--- a/src/components/GradesView/EditModal/OverrideTable/hooks.js
+++ b/src/components/GradesView/EditModal/OverrideTable/hooks.js
@@ -9,7 +9,7 @@ const useOverrideTableData = () => {
   const { formatMessage } = useIntl();
 
   const hide = selectors.grades.useHasOverrideErrors();
-  const gradeOverrides = selectors.grades.useGradeData().gradeOverrideHistoryResults;
+  const gradeOverrides = selectors.grades.useGradeData().gradeOverrideHistoryResults || [];
   const tableProps = {};
   if (!hide) {
     tableProps.columns = [


### PR DESCRIPTION
**as per** [384 number bug](https://github.com/openedx/frontend-app-gradebook/issues/384)

https://github.com/openedx/frontend-app-gradebook/assets/127923546/9fd9edaf-9155-4ed2-84cb-3f69f51fbb44


**LMS Logs**
```
> tutor_nightly_dev-lms-1  |     return self.get_db_prep_value(value, connection=connection, prepared=False)
> tutor_nightly_dev-lms-1  |   File "/openedx/venv/lib/python3.8/site-packages/django/db/models/fields/__init__.py", line 947, in get_db_prep_value
> tutor_nightly_dev-lms-1  |     value = self.get_prep_value(value)
> tutor_nightly_dev-lms-1  |   File "/openedx/venv/lib/python3.8/site-packages/django/db/models/fields/__init__.py", line 1959, in get_prep_value
> tutor_nightly_dev-lms-1  |     raise e.__class__(
> tutor_nightly_dev-lms-1  | ValueError: Field 'earned_graded_override' expected a number but got ''.
```
**Solution**
> **The || [] in the line const gradeOverrides = selectors.grades.useGradeData().gradeOverrideHistoryResults || []; provides a fallback. If gradeOverrideHistoryResults is falsy (like undefined, null, or 0), it defaults to an empty array []. This ensures gradeOverrides always has an array value, preventing potential errors.**