### PR TITLE
fix: Grade value is displayed in the modal

### DIFF
--- a/src/components/GradesView/EditModal/ModalHeaders.jsx
+++ b/src/components/GradesView/EditModal/ModalHeaders.jsx
@@ -22,7 +22,7 @@ export const HistoryKeys = StrictDict({
  */
 export const ModalHeaders = () => {
   const { assignmentName, updateUserName } = selectors.app.useModalData();
-  const { currentGrade, originalGrade } = selectors.grades.useGradeData();
+  const { gradeOverrideCurrentEarnedGradedOverride, gradeOriginalEarnedGraded } = selectors.grades.useGradeData();
   const { formatMessage } = useIntl();
   return (
     <div>
@@ -39,12 +39,12 @@ export const ModalHeaders = () => {
       <HistoryHeader
         id={HistoryKeys.originalGrade}
         label={formatMessage(messages.originalGradeHeader)}
-        value={originalGrade}
+        value={gradeOriginalEarnedGraded}
       />
       <HistoryHeader
         id={HistoryKeys.currentGrade}
         label={formatMessage(messages.currentGradeHeader)}
-        value={currentGrade}
+        value={gradeOverrideCurrentEarnedGradedOverride}
       />
     </div>
   );

--- a/src/components/GradesView/EditModal/ModalHeaders.test.jsx
+++ b/src/components/GradesView/EditModal/ModalHeaders.test.jsx
@@ -25,8 +25,8 @@ const modalData = {
 };
 selectors.app.useModalData.mockReturnValue(modalData);
 const gradeData = {
-  currentGrade: 'test-current-grade',
-  originalGrade: 'test-original-grade',
+  gradeOverrideCurrentEarnedGradedOverride: 'test-current-grade',
+  gradeOriginalEarnedGraded: 'test-original-grade',
 };
 selectors.grades.useGradeData.mockReturnValue(gradeData);
 
@@ -70,7 +70,7 @@ describe('ModalHeaders', () => {
       expect(headerProps).toMatchObject({
         id: HistoryKeys.originalGrade,
         label: formatMessage(messages.originalGradeHeader),
-        value: gradeData.originalGrade,
+        value: gradeData.gradeOriginalEarnedGraded,
       });
     });
     test('currentGrade header', () => {
@@ -78,7 +78,7 @@ describe('ModalHeaders', () => {
       expect(headerProps).toMatchObject({
         id: HistoryKeys.currentGrade,
         label: formatMessage(messages.currentGradeHeader),
-        value: gradeData.currentGrade,
+        value: gradeData.gradeOverrideCurrentEarnedGradedOverride,
       });
     });
   });


### PR DESCRIPTION
**TL;DR -**

`Original Grade` value is not displayed:
    <img width="1370" alt="gr_0" src="https://github.com/openedx/frontend-app-gradebook/assets/98233552/87eed5a1-b2da-4e05-8cac-de6fc99ff9a4">

This value was available on the Palm release:
    <img width="1179" alt="gr_1" src="https://github.com/openedx/frontend-app-gradebook/assets/98233552/55461851-63be-4b93-8477-f8afbb77b613">

That's how it was in [Palm](https://github.com/DmytroAlipov/frontend-app-gradebook/blob/3644172d9471ed3299a9b5accece072b99a7582a/src/components/GradesView/EditModal/ModalHeaders.jsx#L65)

This is the data contained in `selectors.grades.useGradeData`:
```
{
    "courseId": "course-v1:RG+New-course-2+2024",
    "filteredUsersCount": 10,
    "totalUsersCount": 11,
    "gradeFormat": "percent",
    "showSpinner": false,
    "gradeOverrideCurrentEarnedGradedOverride": null,
    "gradeOverrideHistoryResults": [],
    "gradeOriginalEarnedGraded": 1,
    "gradeOriginalPossibleGraded": 1,
    "nextPage": null,
    "prevPage": null,
    "showSuccess": false,
}
```

**Developer Checklist**
- [ ] Test suites passing
- [ ] Documentation and test plan updated, if applicable
- [ ] Received code-owner approving review

**Testing Instructions**
1. As instructor open `Instructor` tab
2. go to `Student admin`
3. click `View Gradebook`
4. Click on available grade:
    <img width="1390" alt="gp_3" src="https://github.com/openedx/frontend-app-gradebook/assets/98233552/a38634f9-20d4-41dc-a0e1-0eab0388c7bb">
5. Check `Original Grade` value


**After these fixes everything works correctly:**
<img width="1370" alt="gr_2" src="https://github.com/openedx/frontend-app-gradebook/assets/98233552/abd4de5e-49ef-4074-a196-010c6eb0a21f">

FYI: @openedx/content-aurora
