### PR TITLE
fix: max adjusted grades warning and error

### DIFF
--- a/src/components/BulkManagementHistoryView/__snapshots__/HistoryTable.test.jsx.snap
+++ b/src/components/BulkManagementHistoryView/__snapshots__/HistoryTable.test.jsx.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`HistoryTable component snapshot history table data (from bulkManagementHistory.map(this.formatHistoryRow) snapshot: maps resultsSummay to ResultsSummary, wraps filename and user, forwards the rest 1`] = `
-[
-  {
+Array [
+  Object {
     "filename": <span
       className="wrap-text-in-cell"
     >
@@ -20,7 +20,7 @@ exports[`HistoryTable component snapshot history table data (from bulkManagement
       Eifel
     </span>,
   },
-  {
+  Object {
     "filename": <span
       className="wrap-text-in-cell"
     >
@@ -45,26 +45,26 @@ exports[`HistoryTable component snapshot snapshot - loads formatted table 1`] = 
 <DataTable
   className="table-striped"
   columns={
-    [
-      {
+    Array [
+      Object {
         "Header": "Gradebook",
         "accessor": "filename",
         "columnSortable": false,
         "width": "col-5",
       },
-      {
+      Object {
         "Header": "Download Summary",
         "accessor": "resultsSummary",
         "columnSortable": false,
         "width": "col",
       },
-      {
+      Object {
         "Header": "Who",
         "accessor": "user",
         "columnSortable": false,
         "width": "col-1",
       },
-      {
+      Object {
         "Header": "When",
         "accessor": "timeUploaded",
         "columnSortable": false,
@@ -73,8 +73,8 @@ exports[`HistoryTable component snapshot snapshot - loads formatted table 1`] = 
     ]
   }
   data={
-    [
-      {
+    Array [
+      Object {
         "filename": <span
           className="wrap-text-in-cell"
         >
@@ -92,7 +92,7 @@ exports[`HistoryTable component snapshot snapshot - loads formatted table 1`] = 
           Eifel
         </span>,
       },
-      {
+      Object {
         "filename": <span
           className="wrap-text-in-cell"
         >

--- a/src/components/BulkManagementHistoryView/__snapshots__/ResultsSummary.test.jsx.snap
+++ b/src/components/BulkManagementHistoryView/__snapshots__/ResultsSummary.test.jsx.snap
@@ -4,8 +4,8 @@ exports[`ResultsSummary component snapshot - safe hyperlink with bulkGradesUrl w
 <Hyperlink
   destination="www.edx.org"
   href={
-    {
-      "url": {
+    Object {
+      "url": Object {
         "rowId": 42,
       },
     }

--- a/src/components/GradebookFilters/AssignmentFilter/__snapshots__/index.test.jsx.snap
+++ b/src/components/GradebookFilters/AssignmentFilter/__snapshots__/index.test.jsx.snap
@@ -10,7 +10,7 @@ exports[`AssignmentFilter component render snapshot 1`] = `
     label="Assignment"
     onChange={[MockFunction]}
     options={
-      [
+      Array [
         <option
           value=""
         >

--- a/src/components/GradebookFilters/AssignmentTypeFilter/__snapshots__/index.test.jsx.snap
+++ b/src/components/GradebookFilters/AssignmentTypeFilter/__snapshots__/index.test.jsx.snap
@@ -10,7 +10,7 @@ exports[`AssignmentFilterType component render snapshot 1`] = `
     label="Assignment Types"
     onChange={[MockFunction]}
     options={
-      [
+      Array [
         <option
           value=""
         >

--- a/src/components/GradebookFilters/StudentGroupsFilter/__snapshots__/index.test.jsx.snap
+++ b/src/components/GradebookFilters/StudentGroupsFilter/__snapshots__/index.test.jsx.snap
@@ -7,7 +7,7 @@ exports[`StudentGroupsFilter component render snapshot 1`] = `
     label="Tracks"
     onChange={[MockFunction]}
     options={
-      [
+      Array [
         <option
           value="Track-All"
         >
@@ -43,7 +43,7 @@ exports[`StudentGroupsFilter component render snapshot 1`] = `
     label="Cohorts"
     onChange={[MockFunction]}
     options={
-      [
+      Array [
         <option
           value="Cohort-All"
         >

--- a/src/components/GradesView/BulkManagementControls/__snapshots__/index.test.jsx.snap
+++ b/src/components/GradesView/BulkManagementControls/__snapshots__/index.test.jsx.snap
@@ -6,7 +6,7 @@ exports[`BulkManagementControls render snapshot - show - network and import butt
 >
   <NetworkButton
     label={
-      {
+      Object {
         "defaultMessage": "Download Grades",
         "description": "A labeled button that allows an admin user to download course grades all at once (in bulk).",
         "id": "gradebook.GradesView.BulkManagementControls.bulkManagementLabel",

--- a/src/components/GradesView/EditModal/OverrideTable/AdjustedGradeInput/__snapshots__/index.test.jsx.snap
+++ b/src/components/GradesView/EditModal/OverrideTable/AdjustedGradeInput/__snapshots__/index.test.jsx.snap
@@ -5,7 +5,8 @@ exports[`AdjustedGradeInput component render snapshot 1`] = `
   <Form.Control
     name="adjustedGradeValue"
     onChange={[MockFunction hook.onChange]}
-    type="text"
+    size="sm"
+    type="number"
     value="test-value"
   />
   some-hint-text

--- a/src/components/GradesView/EditModal/OverrideTable/AdjustedGradeInput/hooks.js
+++ b/src/components/GradesView/EditModal/OverrideTable/AdjustedGradeInput/hooks.js
@@ -15,6 +15,7 @@ const useAdjustedGradeInputData = () => {
     value,
     onChange,
     hintText,
+    possibleGrade,
   };
 };
 

--- a/src/components/GradesView/EditModal/OverrideTable/AdjustedGradeInput/index.jsx
+++ b/src/components/GradesView/EditModal/OverrideTable/AdjustedGradeInput/index.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 
 import { Form } from '@openedx/paragon';
+import { useIntl } from '@edx/frontend-platform/i18n';
+import messages from '../messages';
 
 import useAdjustedGradeInputData from './hooks';
 
@@ -13,17 +15,22 @@ export const AdjustedGradeInput = () => {
   const {
     value,
     onChange,
+    possibleGrade,
     hintText,
   } = useAdjustedGradeInputData();
+
+  const { formatMessage } = useIntl();
+
   return (
     <span>
       <Form.Control
-        type="text"
+        type="number"
         name="adjustedGradeValue"
         value={value}
         onChange={onChange}
+        size="sm"
       />
-      {hintText}
+      {value > possibleGrade ? <div style={{ color: 'red' }}>{ formatMessage(messages.adjustedGradeError)}</div> : hintText}
     </span>
   );
 };

--- a/src/components/GradesView/EditModal/OverrideTable/__snapshots__/index.test.jsx.snap
+++ b/src/components/GradesView/EditModal/OverrideTable/__snapshots__/index.test.jsx.snap
@@ -4,16 +4,16 @@ exports[`OverrideTable component render snapshot 1`] = `
 <DataTable
   columns="test-columns"
   data={
-    [
-      {
+    Array [
+      Object {
         "test": "data",
       },
-      {
+      Object {
         "andOther": "test-data",
       },
-      {
+      Object {
         "adjustedGrade": <AdjustedGradeInput />,
-        "date": {
+        "date": Object {
           "formatted": 2000-01-01T00:00:00.000Z,
         },
         "reason": <ReasonInput />,

--- a/src/components/GradesView/EditModal/OverrideTable/messages.js
+++ b/src/components/GradesView/EditModal/OverrideTable/messages.js
@@ -21,6 +21,11 @@ const messages = defineMessages({
     defaultMessage: 'Reason',
     description: 'Edit Modal Override Table Reason column header',
   },
+  adjustedGradeError: {
+    id: 'gradebook.GradesView.EditModal.Overrides.adjustedGradeError',
+    defaultMessage: 'The value exceeds the maximum grade: {possibleGrade}',
+    description: 'Edit Modal Override Adjusted Grade Error',
+  },
 });
 
 export default messages;

--- a/src/components/GradesView/EditModal/__snapshots__/index.test.jsx.snap
+++ b/src/components/GradesView/EditModal/__snapshots__/index.test.jsx.snap
@@ -36,6 +36,7 @@ exports[`EditModal component render with error snapshot 1`] = `
         Cancel
       </ModalDialog.CloseButton>
       <Button
+        disabled={false}
         onClick={[MockFunction hooks.handleAdjustedGradeClick]}
         variant="primary"
       >
@@ -80,6 +81,7 @@ exports[`EditModal component render without error snapshot 1`] = `
         Cancel
       </ModalDialog.CloseButton>
       <Button
+        disabled={false}
         onClick={[MockFunction hooks.handleAdjustedGradeClick]}
         variant="primary"
       >

--- a/src/components/GradesView/EditModal/index.jsx
+++ b/src/components/GradesView/EditModal/index.jsx
@@ -12,6 +12,7 @@ import OverrideTable from './OverrideTable';
 import ModalHeaders from './ModalHeaders';
 import useEditModalData from './hooks';
 import messages from './messages';
+import useAdjustedGradeInputData from './OverrideTable/AdjustedGradeInput/hooks';
 
 /**
  * <EditModal />
@@ -30,6 +31,11 @@ export const EditModal = () => {
     handleAdjustedGradeClick,
     isOpen,
   } = useEditModalData();
+
+  const {
+    value,
+    possibleGrade,
+  } = useAdjustedGradeInputData();
 
   return (
     <ModalDialog
@@ -57,7 +63,7 @@ export const EditModal = () => {
           <ModalDialog.CloseButton variant="tertiary">
             {formatMessage(messages.closeText)}
           </ModalDialog.CloseButton>
-          <Button variant="primary" onClick={handleAdjustedGradeClick}>
+          <Button variant="primary" onClick={handleAdjustedGradeClick} disabled={value > possibleGrade}>
             {formatMessage(messages.saveGrade)}
           </Button>
         </ActionRow>

--- a/src/components/GradesView/EditModal/index.test.jsx
+++ b/src/components/GradesView/EditModal/index.test.jsx
@@ -14,10 +14,12 @@ import OverrideTable from './OverrideTable';
 import useEditModalData from './hooks';
 import EditModal from '.';
 import messages from './messages';
+import useAdjustedGradeInputData from './OverrideTable/AdjustedGradeInput/hooks';
 
 jest.mock('./hooks', () => jest.fn());
 jest.mock('./ModalHeaders', () => 'ModalHeaders');
 jest.mock('./OverrideTable', () => 'OverrideTable');
+jest.mock('./OverrideTable/AdjustedGradeInput/hooks', () => jest.fn());
 
 const hookProps = {
   onClose: jest.fn().mockName('hooks.onClose'),
@@ -26,6 +28,12 @@ const hookProps = {
   isOpen: 'test-is-open',
 };
 useEditModalData.mockReturnValue(hookProps);
+
+const adjustedGradeProps = {
+  value: 50,
+  possibleGrade: 100,
+};
+useAdjustedGradeInputData.mockReturnValue(adjustedGradeProps);
 
 let el;
 describe('EditModal component', () => {
@@ -39,6 +47,7 @@ describe('EditModal component', () => {
     });
     it('initializes component hooks', () => {
       expect(useEditModalData).toHaveBeenCalled();
+      expect(useAdjustedGradeInputData).toHaveBeenCalled();
     });
   });
   describe('render', () => {
@@ -88,16 +97,18 @@ describe('EditModal component', () => {
         expect(button.children[0].el).toEqual(formatMessage(messages.closeText));
         expect(button.type).toEqual('ModalDialog.CloseButton');
       });
-      test('adjusted grade button', () => {
+      test('adjusted grade button enabled', () => {
         const button = footer[1].findByType(ActionRow)[0].children[1];
         expect(button.children[0].el).toEqual(formatMessage(messages.saveGrade));
         expect(button.type).toEqual('Button');
         expect(button.props.onClick).toEqual(hookProps.handleAdjustedGradeClick);
+        expect(button.props.disabled).toEqual(false);
       });
     };
     describe('without error', () => {
       beforeEach(() => {
         useEditModalData.mockReturnValueOnce({ ...hookProps, error: undefined });
+        useAdjustedGradeInputData.mockReturnValueOnce({ value: 50, possibleGrade: 100 });
         el = shallow(<EditModal />);
       });
       test('snapshot', () => {
@@ -123,6 +134,16 @@ describe('EditModal component', () => {
         expect(alert.children[0].el).toEqual(hookProps.error);
       });
       testFooter();
+    });
+    describe('when the adjusted grade button is disabled', () => {
+      beforeEach(() => {
+        useAdjustedGradeInputData.mockReturnValueOnce({ value: 101, possibleGrade: 100 });
+        el = shallow(<EditModal />);
+      });
+      test('adjusted grade button is disabled', () => {
+        const button = el.instance.findByType(ActionRow)[0].children[1];
+        expect(button.props.disabled).toEqual(true);
+      });
     });
   });
 });

--- a/src/components/GradesView/FilterBadges/__snapshots__/FilterBadge.test.jsx.snap
+++ b/src/components/GradesView/FilterBadges/__snapshots__/FilterBadge.test.jsx.snap
@@ -19,8 +19,8 @@ exports[`FilterBadge render do not hide value snapshot 1`] = `
       aria-label="close"
       className="btn-info"
       onClick={
-        {
-          "handleClose": [
+        Object {
+          "handleClose": Array [
             "some",
             "filters",
           ],
@@ -55,8 +55,8 @@ exports[`FilterBadge render hide Value snapshot 1`] = `
       aria-label="close"
       className="btn-info"
       onClick={
-        {
-          "handleClose": [
+        Object {
+          "handleClose": Array [
             "some",
             "filters",
           ],

--- a/src/components/GradesView/FilteredUsersLabel/__snapshots__/index.test.jsx.snap
+++ b/src/components/GradesView/FilteredUsersLabel/__snapshots__/index.test.jsx.snap
@@ -3,14 +3,14 @@
 exports[`FilteredUsersLabel component render snapshot 1`] = `
 <format-message-function
   message={
-    {
+    Object {
       "defaultMessage": "Showing {filteredUsers} of {totalUsers} total learners",
       "description": "Users visibility label",
       "id": "gradebook.GradesTab.usersVisibilityLabel",
     }
   }
   values={
-    {
+    Object {
       "filteredUsers": <BoldText
         text={100}
       />,

--- a/src/components/GradesView/GradebookTable/__snapshots__/Fields.test.jsx.snap
+++ b/src/components/GradesView/GradebookTable/__snapshots__/Fields.test.jsx.snap
@@ -28,32 +28,32 @@ exports[`Gradebook Table Fields Username with external_user_key snapshot 1`] = `
 `;
 
 exports[`Gradebook Table Fields Username with external_user_key wraps external user key and username 1`] = `
-{
-  "children": [
-    {
-      "children": [
-        {
-          "children": [
+Object {
+  "children": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
             "MyNameFromHere",
           ],
-          "props": {},
+          "props": Object {},
           "type": "div",
         },
-        {
-          "children": [
+        Object {
+          "children": Array [
             "My name from another land",
           ],
-          "props": {
+          "props": Object {
             "className": "student-key",
           },
           "type": "div",
         },
       ],
-      "props": {},
+      "props": Object {},
       "type": "div",
     },
   ],
-  "props": {
+  "props": Object {
     "className": "wrap-text-in-cell",
   },
   "type": "span",

--- a/src/components/GradesView/GradebookTable/__snapshots__/LabelReplacements.test.jsx.snap
+++ b/src/components/GradesView/GradebookTable/__snapshots__/LabelReplacements.test.jsx.snap
@@ -32,7 +32,7 @@ exports[`LabelReplacements TotalGradeLabelReplacement snapshot 1`] = `
     }
     placement="left"
     trigger={
-      [
+      Array [
         "hover",
         "focus",
       ]
@@ -84,7 +84,7 @@ exports[`snapshot left to right overlay placement 1`] = `
     }
     placement="right"
     trigger={
-      [
+      Array [
         "hover",
         "focus",
       ]
@@ -118,7 +118,7 @@ exports[`snapshot right to left overlay placement 1`] = `
     }
     placement="left"
     trigger={
-      [
+      Array [
         "hover",
         "focus",
       ]

--- a/src/components/GradesView/GradebookTable/__snapshots__/index.test.jsx.snap
+++ b/src/components/GradesView/GradebookTable/__snapshots__/index.test.jsx.snap
@@ -7,13 +7,13 @@ exports[`GradebookTable snapshot 1`] = `
   <DataTable
     RowStatusComponent={[MockFunction hooks.nullMethod]}
     columns={
-      [
+      Array [
         "some",
         "columns",
       ]
     }
     data={
-      [
+      Array [
         "some",
         "data",
       ]

--- a/src/components/GradesView/ImportGradesButton/__snapshots__/index.test.jsx.snap
+++ b/src/components/GradesView/ImportGradesButton/__snapshots__/index.test.jsx.snap
@@ -41,7 +41,7 @@ exports[`ImportGradesButton component render snapshot 1`] = `
     className="import-grades-btn"
     import={true}
     label={
-      {
+      Object {
         "defaultMessage": "Import Grades",
         "description": "A labeled button to import grades in the BulkManagement Tab File Upload Form",
         "id": "gradebook.GradesView.importGradesBtnText",

--- a/src/components/GradesView/InterventionsReport/__snapshots__/index.test.jsx.snap
+++ b/src/components/GradesView/InterventionsReport/__snapshots__/index.test.jsx.snap
@@ -17,7 +17,7 @@ exports[`InterventionsReport component output snapshot 1`] = `
     </div>
     <NetworkButton
       label={
-        {
+        Object {
           "defaultMessage": "Download Interventions",
           "description": "The labeled button to download the Intervention report from the Grades View",
           "id": "gradebook.GradesView.InterventionsReport.downloadBtn",

--- a/src/components/GradesView/PageButtons/__snapshots__/index.test.jsx.snap
+++ b/src/components/GradesView/PageButtons/__snapshots__/index.test.jsx.snap
@@ -4,7 +4,7 @@ exports[`PageButtons component render snapshot 1`] = `
 <div
   className="d-flex justify-content-center"
   style={
-    {
+    Object {
       "paddingBottom": "20px",
     }
   }
@@ -13,7 +13,7 @@ exports[`PageButtons component render snapshot 1`] = `
     disabled="prev-disabled"
     onClick={[MockFunction hooks.prev.onClick]}
     style={
-      {
+      Object {
         "margin": "20px",
       }
     }
@@ -25,7 +25,7 @@ exports[`PageButtons component render snapshot 1`] = `
     disabled="next-disabled"
     onClick={[MockFunction hooks.next.onClick]}
     style={
-      {
+      Object {
         "margin": "20px",
       }
     }

--- a/src/components/NetworkButton/__snapshots__/test.jsx.snap
+++ b/src/components/NetworkButton/__snapshots__/test.jsx.snap
@@ -4,12 +4,12 @@ exports[`NetworkButton component snapshots snapshot 1`] = `
 <StatefulButton
   className="ml-2 test-class"
   disabledStates={
-    [
+    Array [
       "pending",
     ]
   }
   icons={
-    {
+    Object {
       "default": <Icon
         className="fa mr-2 fa-download"
       />,
@@ -19,7 +19,7 @@ exports[`NetworkButton component snapshots snapshot 1`] = `
     }
   }
   labels={
-    {
+    Object {
       "default": <FormattedMessage
         defaultMessage="test button label"
         description="test button label description"


### PR DESCRIPTION
Fix: message error if the input is greater than the adjusted grade. 

Fixes #394 

**What changed?**

- Fixed the adjusted grade by comparing the input value with the **possibleGrade** (the maximum grade can take) and enabling the save button only if the value is minor than the **possibleGrade**.
- Modify the **useAdjustedGradeInputData** hook to return the possible grade that we need in the comparison above.

![image](https://github.com/user-attachments/assets/5d38283b-cf9d-47a6-b8ac-6b0156ddebcd)

![image](https://github.com/user-attachments/assets/5d3acd26-0afe-4468-b38d-98061195084b)

![image](https://github.com/user-attachments/assets/505c005e-70ff-432a-b7bc-a08f3a48a42f)


**Developer Checklist**
- [x] Test suites passing
- [x] Documentation and test plan updated, if applicable
- [ ] Received code-owner approving review
- [ ] Bumped version number [package.json](../package.json)

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [x] I've done a visual code review
- [x] I've tested the new functionality


FYI: @openedx/content-aurora
