### PR TITLE
build: remove unused reactifex packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@edx/frontend-component-header": "^6.6.1",
         "@edx/frontend-platform": "^8.3.7",
         "@edx/openedx-atlas": "^0.6.0",
-        "@edx/reactifex": "^2.1.1",
         "@fortawesome/fontawesome-svg-core": "^1.2.25",
         "@fortawesome/free-brands-svg-icons": "^5.11.2",
         "@fortawesome/free-solid-svg-icons": "^5.11.2",
@@ -58,7 +57,6 @@
         "jest": "^29.7.0",
         "react-dev-utils": "^12.0.1",
         "react-test-renderer": "^18.3.1",
-        "reactifex": "1.1.1",
         "redux-mock-store": "^1.5.3"
       }
     },
@@ -2499,28 +2497,6 @@
       "license": "AGPL-3.0",
       "bin": {
         "atlas": "atlas"
-      }
-    },
-    "node_modules/@edx/reactifex": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@edx/reactifex/-/reactifex-2.2.0.tgz",
-      "integrity": "sha512-vyGDtx3BwCr6Gjbm4y6gJ8Bzc2TOSNBlBa2hMerz59HoXaot14MihxxiDU+JDNybGLLcKDBiK511bOi/77i1lw==",
-      "license": "MIT",
-      "dependencies": {
-        "axios": "^0.21.1",
-        "yargs": "^17.1.1"
-      },
-      "bin": {
-        "edx_reactifex": "main.js"
-      }
-    },
-    "node_modules/@edx/reactifex/node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.14.0"
       }
     },
     "node_modules/@edx/typescript-config": {
@@ -18739,16 +18715,6 @@
       "peerDependencies": {
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
-      }
-    },
-    "node_modules/reactifex": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/reactifex/-/reactifex-1.1.1.tgz",
-      "integrity": "sha512-HH2N/b5tRxh7ypIgCRsiBl/CTxRkTEPf9DhIstaM6hne4WiwM5/bBbWuvVlRZc/i3FdqZED3pZ//6n4mtxma4w==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "reactifex": "main.js"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "@edx/frontend-component-header": "^6.6.1",
     "@edx/frontend-platform": "^8.3.7",
     "@edx/openedx-atlas": "^0.6.0",
-    "@edx/reactifex": "^2.1.1",
     "@fortawesome/fontawesome-svg-core": "^1.2.25",
     "@fortawesome/free-brands-svg-icons": "^5.11.2",
     "@fortawesome/free-solid-svg-icons": "^5.11.2",
@@ -78,7 +77,6 @@
     "jest": "^29.7.0",
     "react-dev-utils": "^12.0.1",
     "react-test-renderer": "^18.3.1",
-    "reactifex": "1.1.1",
     "redux-mock-store": "^1.5.3"
   }
 }


### PR DESCRIPTION
Remove reactifex and/or @edx/reactifex packages from devDependencies
as they are no longer needed. Translation extraction functionality has
been verified to work correctly without these dependencies.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
