### PR TITLE
fix: read DISPLAY_FEEDBACK_WIDGET from getConfig instead of process.env

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -42,6 +42,7 @@ initialize({
         SECURE_COOKIES: process.env.NODE_ENV !== 'development',
         SEGMENT_KEY: process.env.SEGMENT_KEY,
         ACCESS_TOKEN_COOKIE_NAME: process.env.ACCESS_TOKEN_COOKIE_NAME,
+        DISPLAY_FEEDBACK_WIDGET: process.env.DISPLAY_FEEDBACK_WIDGET,
       });
     },
   },

--- a/src/lightning.js
+++ b/src/lightning.js
@@ -1,5 +1,7 @@
-module.exports = () => {
-  if (process.env.DISPLAY_FEEDBACK_WIDGET === "true") {
+import { getConfig } from '@edx/frontend-platform';
+
+const lightning = () => {
+  if (getConfig().DISPLAY_FEEDBACK_WIDGET === "true") {
     window.lightningjs ||
       (function (n) {
         var e = "lightningjs";
@@ -129,3 +131,5 @@ module.exports = () => {
     );
   }
 };
+
+export default lightning;


### PR DESCRIPTION
## Summary

This PR updates the feedback widget initialization to read `DISPLAY_FEEDBACK_WIDGET` from the runtime configuration (`getConfig()`) instead of directly from `process.env`.

## Problem

Previously, the value was read using:

```js
process.env.DISPLAY_FEEDBACK_WIDGET
```

This makes the flag **build-time only**, meaning it cannot be overridden dynamically in Tutor-based deployments.

As a result, when patching or overriding environment variables via Tutor, the value would not change unless the MFE was rebuilt.

## Root Cause

`process.env` values are inlined at build time by Webpack. In Open edX MFEs, deploy-time configuration is expected to be accessed via:

```js
getConfig()
```

Using `process.env` directly prevents runtime overrides and breaks Tutor patching behavior.

## Fix

Replaced:

```js
process.env.DISPLAY_FEEDBACK_WIDGET
```

With:

```js
getConfig().DISPLAY_FEEDBACK_WIDGET
```

This aligns with standard Open edX MFE configuration patterns and allows the flag to be properly overridden in Tutor environments.

## Impact

* Enables runtime configurability.
* Restores expected Tutor override behavior.
* No functional change beyond configuration handling.

---
