### PR TITLE
refactor: migrate enrollment API calls from v1 to v2

### DIFF
--- a/src/data/services/lms/urls.js
+++ b/src/data/services/lms/urls.js
@@ -7,7 +7,7 @@ const courseId = window.location.pathname.split('/').filter(Boolean).pop() || ''
 
 export const getUrlPrefix = () => `${getConfig().LMS_BASE_URL}/api/`;
 export const getBulkGradesUrl = () => `${getUrlPrefix()}bulk_grades/course/${courseId}/`;
-export const getEnrollmentUrl = () => `${getUrlPrefix()}enrollment/v1/`;
+export const getEnrollmentUrl = () => `${getUrlPrefix()}enrollment/v2/`;
 export const getGradesUrl = () => `${getUrlPrefix()}grades/v1/`;
 export const getGradebookUrl = () => `${getGradesUrl()}gradebook/${courseId}/`;
 export const getBulkUpdateUrl = () => `${getGradebookUrl()}bulk-update`;


### PR DESCRIPTION
## Summary

Migrates the two enrollment API call sites in Gradebook from `/api/enrollment/v1/` to `/api/enrollment/v2/`, per the FC-0118 API standardization work on `openedx/edx-platform`.

Both callers build on the single `getEnrollmentUrl()` helper, so this is a one-line change in `src/data/services/lms/urls.js`:

| Helper | Old | New |
|---|---|---|
| `getTracksUrl()` | `GET /api/enrollment/v1/course/{course_id}?include_expired=1` | `GET /api/enrollment/v2/course/{course_id}?include_expired=1` |
| `getRolesUrl()` | `GET /api/enrollment/v1/roles/` | `GET /api/enrollment/v2/roles/` |

## Compatibility

The v2 endpoints are behaviour-compatible with v1 for these calls:
- `CourseEnrollmentDetailView` (course tracks) still honours `?include_expired`.
- `UserRolesView` (roles) reads `course_key`/`course_id`. Note: Gradebook passes `?courseId=` (camelCase), which was **already ignored** by v1's `course_id` reader — so roles have always been returned unfiltered here. v2 preserves that exact behaviour; this PR does not change it. (Filtering could be fixed separately by sending `course_key`.)

## Dependency

⚠️ Requires the Enrollment v2 API to be present on the LMS. It is part of the FC-0118 standardization (`openedx/edx-platform` PR #38724) and must be released before this is deployed.

## Test plan

- [ ] `npm test` — existing `api.test.js` / `urls.test.js` pass (they call the helpers, no hardcoded v1 strings)
- [ ] Manual: Gradebook loads track/mode filters and permission gating against an LMS with v2 enabled

Closes #581

🤖 Generated with [Claude Code](https://claude.com/claude-code)